### PR TITLE
Code improvements

### DIFF
--- a/entity-management-web/src/integration-test/java/eu/europeana/entitymanagement/testutils/BaseMvcTestUtils.java
+++ b/entity-management-web/src/integration-test/java/eu/europeana/entitymanagement/testutils/BaseMvcTestUtils.java
@@ -1,6 +1,7 @@
 package eu.europeana.entitymanagement.testutils;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -18,6 +19,18 @@ public class BaseMvcTestUtils {
 
     public static String loadFile(String resourcePath) throws IOException {
         return IOUtils.toString(BaseMvcTestUtils.class.getResourceAsStream(resourcePath), StandardCharsets.UTF_8).replace("\n", "");
+    }
+
+
+    /**
+     * Gets the "{type}/{namespace}/{identifier}" from an EntityId string
+     */
+    public static String getEntityRequestPath(String entityId) {
+        //entity id is "http://data.europeana.eu/{type}/{identifier}"
+        String[] parts = entityId.split("/");
+
+        // namespace is always base
+        return parts[parts.length - 2] + "/base/" + parts[parts.length - 1];
     }
 
 }

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/service/impl/EntityRecordService.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/service/impl/EntityRecordService.java
@@ -50,14 +50,15 @@ public class EntityRecordService {
      * Creates an {@link EntityRecord} from an {@link EntityPreview}, which
      * is then persisted.
      * 
+     * @param entityCreationRequest         de-referenced XML response instance from Metis
      * @param entityCreationRequest entity request object
-     * @param entity         de-referenced XML response instance from Metis
-     * @return Saved Entity record
+     * @param externalEntityType
+	 * @return Saved Entity record
      * @throws EntityCreationException if an error occurs
      */
-    public EntityRecord createEntityFromRequest(EntityPreview entityCreationRequest, Entity externalEntity)
+    public EntityRecord createEntityFromRequest(EntityPreview entityCreationRequest, String externalEntityType)
 	    throws EntityCreationException {
-	Entity entity = EntityObjectFactory.createEntityObject(externalEntity.getType());
+	Entity entity = EntityObjectFactory.createEntityObject(externalEntityType);
 
 	entity.setPrefLabelStringMap(entityCreationRequest.getPrefLabel());
 	entity.setAltLabel(entityCreationRequest.getAltLabel());


### PR DESCRIPTION
- added support for `/entity/{type}/{identifier}` and `/entity/{type}/base/{identifier}` entity retrieval routes 

- added integration test for entity retrieval

- use external profile by default when retrieving entities

- fixed NPE due to missing entity `aggregatedBy` value