### PR TITLE
Correctly handle entity updates

### DIFF
--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/Entity.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/Entity.java
@@ -48,6 +48,8 @@ public interface Entity extends ContextualClass {
 	
 	WebResource getReferencedWebResource();
 	
+	void setReferencedWebResource(WebResource resource);
+
 	String getIsShownBy();
 	
 	void setIsShownBy (WebResource webResource);

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/Entity.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/Entity.java
@@ -48,8 +48,6 @@ public interface Entity extends ContextualClass {
 	
 	WebResource getReferencedWebResource();
 	
-	void setReferencedWebResource(WebResource resource);
-	
 	String getIsShownBy();
 	
 	void setIsShownBy (WebResource webResource);

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/Entity.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/Entity.java
@@ -1,6 +1,14 @@
 package eu.europeana.entitymanagement.definitions.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import eu.europeana.entitymanagement.definitions.model.impl.AgentImpl;
+import eu.europeana.entitymanagement.definitions.model.impl.ConceptImpl;
+import eu.europeana.entitymanagement.definitions.model.impl.OrganizationImpl;
+import eu.europeana.entitymanagement.definitions.model.impl.PlaceImpl;
+import eu.europeana.entitymanagement.definitions.model.impl.TimespanImpl;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
@@ -13,6 +21,16 @@ import eu.europeana.entitymanagement.definitions.model.impl.BaseEntity;
 
 @Embedded
 @JsonDeserialize(as = BaseEntity.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+		@JsonSubTypes.Type(value = AgentImpl.class, name = "Agent"),
+		@JsonSubTypes.Type(value = ConceptImpl.class, name = "Concept"),
+		@JsonSubTypes.Type(value = OrganizationImpl.class, name = "Organization"),
+		@JsonSubTypes.Type(value = PlaceImpl.class, name = "Place"),
+		@JsonSubTypes.Type(value = TimespanImpl.class, name = "Timespan")
+}
+)
 public interface Entity extends ContextualClass {
 
 	public String[] getIdentifier();

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/impl/BaseEntity.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/impl/BaseEntity.java
@@ -4,17 +4,13 @@ import static eu.europeana.entitymanagement.vocabulary.WebEntityConstants.ENTITY
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSetter;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import dev.morphia.annotations.Transient;
 import eu.europeana.entitymanagement.common.config.ComparisonUtils;
 import eu.europeana.entitymanagement.definitions.model.Aggregation;
 import eu.europeana.entitymanagement.definitions.model.Entity;
-import eu.europeana.entitymanagement.definitions.model.Timespan;
 import eu.europeana.entitymanagement.definitions.model.WebResource;
 import eu.europeana.entitymanagement.normalization.ValidEntityFields;
 import eu.europeana.entitymanagement.vocabulary.WebEntityFields;

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/impl/BaseEntity.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/impl/BaseEntity.java
@@ -35,16 +35,6 @@ import org.bson.types.ObjectId;
  */
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 @ValidEntityFields(groups = {Default.class})
-@JsonIgnoreProperties(ignoreUnknown = true)
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({
-		@JsonSubTypes.Type(value = AgentImpl.class, name = "Agent"),
-		@JsonSubTypes.Type(value = ConceptImpl.class, name = "Concept"),
-		@JsonSubTypes.Type(value = OrganizationImpl.class, name = "Organization") ,
-		@JsonSubTypes.Type(value = PlaceImpl.class, name = "Place"),
-		@JsonSubTypes.Type(value = TimespanImpl.class, name = "Timespan")
-}
-)
 public abstract class BaseEntity implements Entity {
 	
 	public BaseEntity() {

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/impl/BaseEntity.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/impl/BaseEntity.java
@@ -1,40 +1,51 @@
 package eu.europeana.entitymanagement.definitions.model.impl;
 
 import static eu.europeana.entitymanagement.vocabulary.WebEntityConstants.ENTITY_CONTEXT;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.CONTEXT;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.ID;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.TYPE;
-
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import java.lang.reflect.Field;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import javax.validation.groups.Default;
-
-import dev.morphia.annotations.Transient;
-import eu.europeana.entitymanagement.common.config.ComparisonUtils;
-import org.bson.types.ObjectId;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-
+import dev.morphia.annotations.Transient;
+import eu.europeana.entitymanagement.common.config.ComparisonUtils;
 import eu.europeana.entitymanagement.definitions.model.Aggregation;
 import eu.europeana.entitymanagement.definitions.model.Entity;
+import eu.europeana.entitymanagement.definitions.model.Timespan;
 import eu.europeana.entitymanagement.definitions.model.WebResource;
 import eu.europeana.entitymanagement.normalization.ValidEntityFields;
 import eu.europeana.entitymanagement.vocabulary.WebEntityFields;
 import eu.europeana.entitymanagement.vocabulary.XmlFields;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import javax.validation.groups.Default;
+import org.bson.types.ObjectId;
 
 /*
  * TODO: Define the Jackson annotations, both xml and json, in one place, meaning in this class here and the corresponding extended classes 
  */
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 @ValidEntityFields(groups = {Default.class})
-public class BaseEntity implements Entity {
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+		@JsonSubTypes.Type(value = AgentImpl.class, name = "Agent"),
+		@JsonSubTypes.Type(value = ConceptImpl.class, name = "Concept"),
+		@JsonSubTypes.Type(value = OrganizationImpl.class, name = "Organization") ,
+		@JsonSubTypes.Type(value = PlaceImpl.class, name = "Place"),
+		@JsonSubTypes.Type(value = TimespanImpl.class, name = "Timespan")
+}
+)
+public abstract class BaseEntity implements Entity {
 	
 	public BaseEntity() {
 		// TODO Auto-generated constructor stub
@@ -70,12 +81,6 @@ public class BaseEntity implements Entity {
 	@JsonIgnore
 	public WebResource getReferencedWebResource() {
 		return referencedWebResource;
-	}
-	
-	@Override
-	@JsonSetter
-	public void setReferencedWebResource(WebResource resource) {
-		this.referencedWebResource = resource;
 	}
 	
 	@JsonGetter(WebEntityFields.PREF_LABEL)
@@ -143,7 +148,6 @@ public class BaseEntity implements Entity {
 
 	@Override
 	@JsonGetter(WebEntityFields.ID)
-	@JacksonXmlProperty(isAttribute= true, localName = XmlFields.XML_RDF_ABOUT)
 	public String getEntityId() {
 		return entityId;
 	}
@@ -167,6 +171,7 @@ public class BaseEntity implements Entity {
 	}
 
 	@JsonIgnore
+	@JacksonXmlProperty(isAttribute= true, localName = XmlFields.XML_RDF_ABOUT)
 	public String getAbout() {
 		return getEntityId();
 	}
@@ -417,5 +422,4 @@ public class BaseEntity implements Entity {
 		result = 31 * result + Arrays.hashCode(getIdentifier());
 		return result;
 	}
-
 }

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/impl/BaseEntity.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/impl/BaseEntity.java
@@ -83,6 +83,12 @@ public abstract class BaseEntity implements Entity {
 		return referencedWebResource;
 	}
 	
+	@Override
+	@JsonSetter
+	public void setReferencedWebResource(WebResource resource) {
+		this.referencedWebResource = resource;
+	}
+
 	@JsonGetter(WebEntityFields.PREF_LABEL)
 	@JacksonXmlProperty(localName = XmlFields.XML_SKOS_PREF_LABEL)
 	public Map<String, String> getPrefLabelStringMap() {
@@ -148,6 +154,7 @@ public abstract class BaseEntity implements Entity {
 
 	@Override
 	@JsonGetter(WebEntityFields.ID)
+	@JacksonXmlProperty(isAttribute= true, localName = XmlFields.XML_RDF_ABOUT)
 	public String getEntityId() {
 		return entityId;
 	}
@@ -171,7 +178,6 @@ public abstract class BaseEntity implements Entity {
 	}
 
 	@JsonIgnore
-	@JacksonXmlProperty(isAttribute= true, localName = XmlFields.XML_RDF_ABOUT)
 	public String getAbout() {
 		return getEntityId();
 	}
@@ -422,4 +428,5 @@ public abstract class BaseEntity implements Entity {
 		result = 31 * result + Arrays.hashCode(getIdentifier());
 		return result;
 	}
+
 }

--- a/entity-management-utils/src/main/java/eu/europeana/entitymanagement/serialization/EntityXmlSerializer.java
+++ b/entity-management-utils/src/main/java/eu/europeana/entitymanagement/serialization/EntityXmlSerializer.java
@@ -1,13 +1,7 @@
 package eu.europeana.entitymanagement.serialization;
 
-import eu.europeana.entitymanagement.definitions.model.impl.BaseEntity;
-import eu.europeana.entitymanagement.serialization.mixins.XmlIgnoreFieldsMixin;
-import java.io.IOException;
-import java.io.StringWriter;
+import java.util.List;
 
-import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -18,110 +12,127 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 import eu.europeana.entitymanagement.common.config.AppConfigConstants;
 import eu.europeana.entitymanagement.definitions.exceptions.EntityManagementRuntimeException;
+import eu.europeana.entitymanagement.definitions.model.Entity;
+import eu.europeana.entitymanagement.definitions.model.EntityProxy;
 import eu.europeana.entitymanagement.definitions.model.EntityRecord;
+import eu.europeana.entitymanagement.definitions.model.WebResource;
 import eu.europeana.entitymanagement.vocabulary.EntityProfile;
 
 @Component(AppConfigConstants.BEAN_EM_XML_SERIALIZER)
 public class EntityXmlSerializer {
 
-	private final static XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newFactory();
+	final String XML_HEADER_TAG_CONCEPT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+			" <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\r\n" +
+			"         xmlns:foaf=\"http://xmlns.com/foaf/0.1/\"\r\n" +
+			"         xmlns:dc=\"http://purl.org/dc/elements/1.1/\"\r\n" +
+			"         xmlns:edm=\"http://www.europeana.eu/schemas/edm/\"\r\n" +
+			"	  xmlns:ore=\"http://www.openarchives.org/ore/terms/\"\r\n" +
+			"         xmlns:skos=\"http://www.w3.org/2004/02/skos/core#\"\r\n " +
+			"         xmlns:dcterms=\"http://purl.org/dc/terms/\" >";
+	final String XML_HEADER_TAG_AGENT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+			" <rdf:RDF xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"         xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\r\n" +
+			"         xmlns:dc=\"http://purl.org/dc/elements/1.1/\"\r\n" +
+			"         xmlns:edm=\"http://www.europeana.eu/schemas/edm/\"\r\n" +
+			"         xmlns:foaf=\"http://xmlns.com/foaf/0.1/\"\r\n" +
+			"         xmlns:rdaGr2=\"http://rdvocab.info/ElementsGr2/\"\r\n" +
+			"         xmlns:owl=\"http://www.w3.org/2002/07/owl#\"\r\n" +
+			"	  xmlns:ore=\"http://www.openarchives.org/ore/terms/\"\r\n" +
+			"         xmlns:skos=\"http://www.w3.org/2004/02/skos/core#\"\r\n" +
+			"         xmlns:dcterms=\"http://purl.org/dc/terms/\" >";
+	final String XML_HEADER_TAG_PLACE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+			" <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\r\n" +
+			"         xmlns:foaf=\"http://xmlns.com/foaf/0.1/\"\r\n" +
+			"         xmlns:dc=\"http://purl.org/dc/elements/1.1/\"\r\n" +
+			"         xmlns:edm=\"http://www.europeana.eu/schemas/edm/\"\r\n" +
+			"         xmlns:wgs84_pos=\"http://www.w3.org/2003/01/geo/wgs84_pos#\"\r\n" +
+			"         xmlns:owl=\"http://www.w3.org/2002/07/owl#\"\r\n" +
+			"         xmlns:skos=\"http://www.w3.org/2004/02/skos/core#\"\r\n" +
+			"	  xmlns:ore=\"http://www.openarchives.org/ore/terms/\"\r\n" +
+			"         xmlns:dcterms=\"http://purl.org/dc/terms/\" >";
+	final String XML_HEADER_TAG_ORGANIZATION = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+			" <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\r\n" +
+			"         xmlns:foaf=\"http://xmlns.com/foaf/0.1/\"\r\n" +
+			"         xmlns:dc=\"http://purl.org/dc/elements/1.1/\"\r\n" +
+			"         xmlns:edm=\"http://www.europeana.eu/schemas/edm/\"\r\n" +
+			"         xmlns:vcard=\"https://www.w3.org/2006/vcard/\"\r\n" +
+			"         xmlns:owl=\"http://www.w3.org/2002/07/owl#\"\r\n" +
+			"	  xmlns:ore=\"http://www.openarchives.org/ore/terms/\"\r\n" +
+			"         xmlns:skos=\"http://www.w3.org/2004/02/skos/core#\"\r\n " +
+			"         xmlns:dcterms=\"http://purl.org/dc/terms/\" >";
+	final String XML_END_TAG = "</rdf:RDF>";
+	final String XML_HEADER_TAG_TIMESPAN = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+			" <rdf:RDF xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"         xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\r\n" +
+			"         xmlns:dc=\"http://purl.org/dc/elements/1.1/\"\r\n" +
+			"         xmlns:edm=\"http://www.europeana.eu/schemas/edm/\"\r\n" +
+			"         xmlns:foaf=\"http://xmlns.com/foaf/0.1/\"\r\n" +
+			"         xmlns:rdaGr2=\"http://rdvocab.info/ElementsGr2/\"\r\n" +
+			"         xmlns:owl=\"http://www.w3.org/2002/07/owl#\"\r\n" +
+			"	  xmlns:ore=\"http://www.openarchives.org/ore/terms/\"\r\n" +
+			"         xmlns:skos=\"http://www.w3.org/2004/02/skos/core#\"\r\n" +
+			"         xmlns:dcterms=\"http://purl.org/dc/terms/\" >";
 
-	private final XmlMapper xmlMapper;
-
-	public EntityXmlSerializer() {
-		JacksonXmlModule xmlModule = new JacksonXmlModule();
-		xmlModule.setDefaultUseWrapper(false);
-		xmlMapper = new XmlMapper(xmlModule);
-		xmlMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
-		xmlMapper.addMixIn(BaseEntity.class, XmlIgnoreFieldsMixin.class);
+	public String serializeXml(EntityRecord record, String profileString) throws EntityManagementRuntimeException {
+		EntityProfile profile = EntityProfile.valueOf(profileString);
+		String res = null;
+		switch (profile) {
+			case internal:
+				res = serializeXmlInternal(record);
+				break;
+			case external:
+				res = serializeXmlExternal(record);
+				break;
+			default:
+				throw new EntityManagementRuntimeException("Serialization not supported for profile:" + profile);
+		}
+		return res;
 	}
 
-	final String XML_HEADER_TAG_CONCEPT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
-    	    	" <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\r\n" +  
-    	    	"         xmlns:foaf=\"http://xmlns.com/foaf/0.1/\"\r\n" + 
-    	    	"         xmlns:dc=\"http://purl.org/dc/elements/1.1/\"\r\n" + 
-    	    	"         xmlns:edm=\"http://www.europeana.eu/schemas/edm/\"\r\n" + 
-    	    	"	  xmlns:ore=\"http://www.openarchives.org/ore/terms/\"\r\n" +
-    	    	"         xmlns:skos=\"http://www.w3.org/2004/02/skos/core#\"\r\n " +
-		"         xmlns:dcterms=\"http://purl.org/dc/terms/\" >";
-    	final String XML_HEADER_TAG_AGENT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + 
-		" <rdf:RDF xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + 
-		"         xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\r\n" + 
-		"         xmlns:dc=\"http://purl.org/dc/elements/1.1/\"\r\n" + 
-		"         xmlns:edm=\"http://www.europeana.eu/schemas/edm/\"\r\n" + 
-		"         xmlns:foaf=\"http://xmlns.com/foaf/0.1/\"\r\n" + 
-		"         xmlns:rdaGr2=\"http://rdvocab.info/ElementsGr2/\"\r\n" + 
-		"         xmlns:owl=\"http://www.w3.org/2002/07/owl#\"\r\n" + 
-		"	  xmlns:ore=\"http://www.openarchives.org/ore/terms/\"\r\n" +
-		"         xmlns:skos=\"http://www.w3.org/2004/02/skos/core#\"\r\n" + 
-		"         xmlns:dcterms=\"http://purl.org/dc/terms/\" >";
-    	final String XML_HEADER_TAG_PLACE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
-	    	" <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\r\n" + 
-	    	"         xmlns:foaf=\"http://xmlns.com/foaf/0.1/\"\r\n" + 
-	    	"         xmlns:dc=\"http://purl.org/dc/elements/1.1/\"\r\n" + 
-	    	"         xmlns:edm=\"http://www.europeana.eu/schemas/edm/\"\r\n" + 
-	    	"         xmlns:wgs84_pos=\"http://www.w3.org/2003/01/geo/wgs84_pos#\"\r\n" + 
-	    	"         xmlns:owl=\"http://www.w3.org/2002/07/owl#\"\r\n" + 
-	    	"         xmlns:skos=\"http://www.w3.org/2004/02/skos/core#\"\r\n" + 
-	    	"	  xmlns:ore=\"http://www.openarchives.org/ore/terms/\"\r\n" +
-	    	"         xmlns:dcterms=\"http://purl.org/dc/terms/\" >";
-    	final String XML_HEADER_TAG_ORGANIZATION = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + 
-	    	" <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\r\n" + 
-	    	"         xmlns:foaf=\"http://xmlns.com/foaf/0.1/\"\r\n" + 
-	    	"         xmlns:dc=\"http://purl.org/dc/elements/1.1/\"\r\n" + 
-	    	"         xmlns:edm=\"http://www.europeana.eu/schemas/edm/\"\r\n" + 
-	    	"         xmlns:vcard=\"https://www.w3.org/2006/vcard/\"\r\n" + 
-	    	"         xmlns:owl=\"http://www.w3.org/2002/07/owl#\"\r\n" + 
-	    	"	  xmlns:ore=\"http://www.openarchives.org/ore/terms/\"\r\n" +
-	    	"         xmlns:skos=\"http://www.w3.org/2004/02/skos/core#\"\r\n " +
-		"         xmlns:dcterms=\"http://purl.org/dc/terms/\" >";
-    	final String XML_END_TAG = "</rdf:RDF>";
-    	final String XML_HEADER_TAG_TIMESPAN = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + 
-		" <rdf:RDF xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + 
-		"         xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\r\n" + 
-		"         xmlns:dc=\"http://purl.org/dc/elements/1.1/\"\r\n" + 
-		"         xmlns:edm=\"http://www.europeana.eu/schemas/edm/\"\r\n" + 
-		"         xmlns:foaf=\"http://xmlns.com/foaf/0.1/\"\r\n" + 
-		"         xmlns:rdaGr2=\"http://rdvocab.info/ElementsGr2/\"\r\n" + 
-		"         xmlns:owl=\"http://www.w3.org/2002/07/owl#\"\r\n" + 
-		"	  xmlns:ore=\"http://www.openarchives.org/ore/terms/\"\r\n" +
-		"         xmlns:skos=\"http://www.w3.org/2004/02/skos/core#\"\r\n" + 
-		"         xmlns:dcterms=\"http://purl.org/dc/terms/\" >";
-    
-    public String serializeXml(EntityRecord record, String profileString) throws EntityManagementRuntimeException {
-    	EntityProfile profile = EntityProfile.valueOf(profileString);
-    	String res = null;
-    	switch (profile) {
-    	case internal:
-    	    res = serializeXmlInternal(record);
-    	    break;
-    	case external:
-    	    res = serializeXmlExternal(record);
-    	    break;
-    	default:
-    	    throw new EntityManagementRuntimeException("Serialization not supported for profile:" + profile);
-    	}
-    	return res;	    	
-   	}
-
-    /**
+	/**
 	 * This method serializes EntityRecord object to xml formats for the external profile.
 	 * @param entityRecord The EntityRecord object
 	 * @return The serialized entityRecord in the xml string format
-     * @throws EntityManagementRuntimeException 
+	 * @throws EntityManagementRuntimeException
 	 */
 	public String serializeXmlExternal(EntityRecord entityRecord) throws EntityManagementRuntimeException {
-		StringWriter stringWriter = new StringWriter();
-		try {
-			XMLStreamWriter sw = xmlOutputFactory.createXMLStreamWriter(stringWriter);
+		JacksonXmlModule xmlModule = new JacksonXmlModule();
+		xmlModule.setDefaultUseWrapper(true);
+		ObjectMapper objectMapper = new XmlMapper(xmlModule);
+		objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
 
-			sw.writeStartDocument();
-			SerializationUtils.serializeExternalXml(sw, xmlMapper, entityRecord);
-			sw.writeEndDocument();
-			return stringWriter.toString();
-		} catch (IOException | XMLStreamException e) {
+		String output = "";
+		try {
+			output = objectMapper.writeValueAsString(entityRecord.getEntity());
+		} catch (JsonProcessingException e) {
 			throw new EntityManagementRuntimeException("Unexpected exception occured when serializing entity to external format!",e);
 		}
+//
+//		Aggregation tmpAggregation = entityRecord.getEntity().getIsAggregatedBy();
+//		List<EntityProxy> tmpProxies = entityRecord.getProxies();
+//		try {
+////			entityRecord.setIsAggregatedBy(null);
+////			entityRecord.setProxies(null);
+//
+//    		StringBuilder strBuilder = new StringBuilder();
+//		    strBuilder.append(objectMapper.writeValueAsString(entityRecord.getEntity()));
+//
+//		    //add referenced web resources
+//		    WebResource webResource = entityRecord.getEntity().getReferencedWebResource();
+//		    if (webResource!=null)
+//		    {
+//		    	strBuilder.append(objectMapper.writeValueAsString(webResource));
+//		    }
+//
+//		    strBuilder.append(XML_END_TAG);
+//		    output = strBuilder.toString();
+//		} catch (JsonProcessingException e) {
+//		    throw new EntityManagementRuntimeException("Unexpected exception occured when serializing entity to external format!",e);
+//		}
+//
+////		entityRecord.setIsAggregatedBy(tmpAggregation);
+//		entityRecord.setProxies(tmpProxies);
+		return output;
 	}
 
 
@@ -132,15 +143,41 @@ public class EntityXmlSerializer {
 	 * @return The serialized entityRecord in the xml string format
 	 * @throws EntityManagementRuntimeException
 	 */
-	public String serializeXmlInternal(EntityRecord entityRecord)
-			throws EntityManagementRuntimeException {
-		StringWriter stringWriter = new StringWriter();
+	public String serializeXmlInternal(EntityRecord entityRecord) throws EntityManagementRuntimeException {
+		JacksonXmlModule xmlModule = new JacksonXmlModule();
+		xmlModule.setDefaultUseWrapper(true);
+		ObjectMapper objectMapper = new XmlMapper(xmlModule);
+		objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+
+		String output = "";
+
+		Entity tmpEntity = entityRecord.getEntity();
 		try {
-		XMLStreamWriter sw = xmlOutputFactory.createXMLStreamWriter(stringWriter);
-		SerializationUtils.serializeInternalXml(sw, xmlMapper, entityRecord);
-			return stringWriter.toString();
-		} catch (IOException | XMLStreamException e) {
-		    throw new EntityManagementRuntimeException("Unexpected exception occured when serializing entity to external format!",e);
+			entityRecord.setEntity(null);
+
+			StringBuilder strBuilder = new StringBuilder();
+			strBuilder.append(objectMapper.writeValueAsString(entityRecord));
+
+			//adding the referenced web resources for the proxy entities
+			List<EntityProxy> entityRecordProxies = entityRecord.getProxies();
+			for (EntityProxy proxy : entityRecordProxies) {
+				WebResource webResource = null;
+				if (proxy.getEntity()!=null) {
+					webResource= proxy.getEntity().getReferencedWebResource();
+				}
+				if (webResource!=null)
+				{
+					strBuilder.append(objectMapper.writeValueAsString(webResource));
+				}
+			}
+
+			strBuilder.append(XML_END_TAG);
+			output = strBuilder.toString();
+		} catch (JsonProcessingException e) {
+			throw new EntityManagementRuntimeException("Unexpected exception occured when serializing entity to external format!",e);
 		}
-	}	
+
+		entityRecord.setEntity(tmpEntity);
+		return output;
+	}
 }

--- a/entity-management-web/src/integration-test/java/eu/europeana/entitymanagement/web/EMControllerIT.java
+++ b/entity-management-web/src/integration-test/java/eu/europeana/entitymanagement/web/EMControllerIT.java
@@ -272,7 +272,10 @@ public class EMControllerIT extends AbstractIntegrationTest {
         final ObjectNode nodeReference = new ObjectMapper().readValue(loadFile(CONCEPT_UPDATE_JSON), ObjectNode.class);
         Optional<EntityRecord> entityRecordUpdated = entityRecordService.retrieveEntityRecordByUri(registeredEntityNode.path("id").asText());
         Assertions.assertTrue(entityRecordUpdated.isPresent());
-        Assertions.assertTrue(entityRecordUpdated.get().getEuropeanaProxy().getEntity().getDepiction().equals(nodeReference.path("depiction").asText()));
+        Assertions.assertEquals(nodeReference.path("depiction").asText(),
+            entityRecordUpdated.get().getEuropeanaProxy().getEntity().getDepiction());
+        Assertions.assertEquals(nodeReference.path("note").path("en").path(0).asText(),
+            entityRecordUpdated.get().getEuropeanaProxy().getEntity().getNote().get("en").get(0));
         // acquire the reader for the right type
         ObjectReader reader = objectMapper.readerFor(new TypeReference<Map<String,String>>() {});
         Map<String,String> prefLabelToCheck = reader.readValue(nodeReference.path("prefLabel"));

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/EMController.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/EMController.java
@@ -1,6 +1,5 @@
 package eu.europeana.entitymanagement.web;
 
-import eu.europeana.entitymanagement.definitions.model.impl.BaseEntity;
 import java.util.Date;
 import java.util.Optional;
 
@@ -105,7 +104,7 @@ public class EMController extends BaseRest {
 	    @RequestParam(value = WebEntityConstants.QUERY_PARAM_PROFILE, defaultValue = "internal") String profile,
 	    @PathVariable(value = WebEntityConstants.PATH_PARAM_TYPE) String type,
 	    @PathVariable(value = WebEntityConstants.PATH_PARAM_IDENTIFIER) String identifier,
-	    @RequestBody BaseEntity updateRequestEntity,
+	    @RequestBody Entity updateRequestEntity,
 	    HttpServletRequest request) throws Exception {
 
     	// TODO: Re-enable authentication

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/EMController.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/EMController.java
@@ -1,5 +1,6 @@
 package eu.europeana.entitymanagement.web;
 
+import eu.europeana.entitymanagement.definitions.model.impl.BaseEntity;
 import java.util.Date;
 import java.util.Optional;
 
@@ -104,7 +105,7 @@ public class EMController extends BaseRest {
 	    @RequestParam(value = WebEntityConstants.QUERY_PARAM_PROFILE, defaultValue = "internal") String profile,
 	    @PathVariable(value = WebEntityConstants.PATH_PARAM_TYPE) String type,
 	    @PathVariable(value = WebEntityConstants.PATH_PARAM_IDENTIFIER) String identifier,
-	    @RequestBody EntityPreview entityCreationRequest,
+	    @RequestBody BaseEntity updateRequestEntity,
 	    HttpServletRequest request) throws Exception {
 
     	// TODO: Re-enable authentication
@@ -122,26 +123,9 @@ public class EMController extends BaseRest {
 				throw new EtagMismatchException("If-Match header value does not match generated ETag for entity");
 			}
 
-			if(entityCreationRequest.getId()!=null) {
-				entityRecord.getEuropeanaProxy().getEntity().setEntityId(entityCreationRequest.getId());
-			}
-			if(entityCreationRequest.getAltLabel()!=null) {
-				entityRecord.getEuropeanaProxy().getEntity().setAltLabel(entityCreationRequest.getAltLabel());
-			}
-    		if(entityCreationRequest.getDepiction()!=null) {
-					entityRecord.getEuropeanaProxy().getEntity().setDepiction(entityCreationRequest.getDepiction());
-    		}
-    		if(entityCreationRequest.getPrefLabel()!=null) {
-					entityRecord.getEuropeanaProxy().getEntity().setPrefLabelStringMap(entityCreationRequest.getPrefLabel());
-    		}
-
-    		Date modificationDate = new Date();
-    		if (entityRecord.getEuropeanaProxy().getProxyIn()!=null) {
-					entityRecord.getEuropeanaProxy().getProxyIn().setModified(modificationDate);
-    		}
-
-    		entityRecordService.update(entityRecord);
-				return launchTaskAndRetrieveEntity(type, identifier, entityRecord, profile);
+			entityRecordService.updateEuropeanaProxy(updateRequestEntity, entityRecord);
+			entityRecordService.update(entityRecord);
+			return launchTaskAndRetrieveEntity(type, identifier, entityRecord, profile);
     }
 
 

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/EMExceptionHandler.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/EMExceptionHandler.java
@@ -1,9 +1,12 @@
 package eu.europeana.entitymanagement.web;
 
+import eu.europeana.api.commons.error.EuropeanaApiErrorResponse.Builder;
 import javax.servlet.http.HttpServletRequest;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -36,5 +39,14 @@ public class EMExceptionHandler extends EuropeanaGlobalExceptionHandler {
                 .status(e.getStatus())
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(response);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<EuropeanaApiErrorResponse> handleException(HttpMessageNotReadableException e, HttpServletRequest httpRequest) {
+        EuropeanaApiErrorResponse response = new EuropeanaApiErrorResponse.Builder(httpRequest, e, stackTraceEnabled())
+            .setStatus(HttpStatus.BAD_REQUEST.value())
+            .setMessage("'type' property is required for updates. Valid values are 'Agent', 'Concept', 'Organization', 'Place' and 'Timespan'")
+            .build();
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 }

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/service/EntityRecordService.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/service/EntityRecordService.java
@@ -11,6 +11,7 @@ import eu.europeana.entitymanagement.web.EntityRecordUtils;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -61,7 +62,14 @@ public class EntityRecordService {
 
     private final DataSources datasources;
 
-    @Autowired
+	/**
+	 * Fields to ignore when updating entities from user request
+	 */
+	private final List<String> UPDATE_FIELDS_TO_IGNORE = List
+			.of(WebEntityFields.ID, WebEntityFields.IDENTIFIER, WebEntityFields.TYPE,
+					WebEntityFields.IS_AGGREGATED_BY);
+
+	@Autowired
     public EntityRecordService(EntityRecordRepository entityRecordRepository,
 	    EntityManagementConfiguration emConfiguration, DataSources datasources) {
 	this.entityRecordRepository = entityRecordRepository;
@@ -359,79 +367,103 @@ public class EntityRecordService {
 	Entity primary = europeanaProxy.getEntity();
 	Entity secondary = externalProxy.getEntity();
 
-	try {
-	    /*
-	     * store the preferred label in the secondary entity that is different from the
-	     * preferred label in the primary entity to the alternative labels of the
-	     * consolidated entity
-	     */
-	    Map<Object, Object> prefLabelsForAltLabels = new HashMap<>();
+			try {
+				Entity consolidatedEntity = combineEntities(primary, secondary, Collections.emptyList());
+				entityRecord.setEntity(consolidatedEntity);
+			} catch (IllegalArgumentException | IllegalAccessException e) {
+				logger.error(
+						"Error while reconciling entity data", e);
+			}
+		}
 
-	    List<Field> allEntityFields = new ArrayList<>();
-	    EntityUtils.getAllFields(allEntityFields, primary.getClass());
+	/**
+	 * Updates Europeana proxy metadata with the provided entity metadata.
+	 *
+	 * @param updateEntity entity to copy metadata from
+	 * @param entityRecord entity record
+	 * @throws Exception if error occurs
+	 */
+	public void updateEuropeanaProxy(Entity updateEntity, EntityRecord entityRecord)
+		throws Exception {
+	EntityProxy europeanaProxy = entityRecord.getEuropeanaProxy();
 
-	    Entity consilidatedEntity = entityRecord.getEntity();
-	    for (Field field : allEntityFields) {
+// update metadata take precedence over existing ones
+	Entity updatedEntity = combineEntities(updateEntity, europeanaProxy.getEntity(),
+			UPDATE_FIELDS_TO_IGNORE);
+    	europeanaProxy.setEntity(updatedEntity);
 
-		Class<?> fieldType = field.getType();
-		String fieldName = field.getName();
-
-		if (fieldType.isArray()) {
-		    Object[] mergedArray = mergeArrays(primary, secondary, field);
-		    consilidatedEntity.setFieldValue(field, mergedArray);
-			    
-//		    if (fieldValuePrimaryObject != null) {
-//			entityRecord.getEntity().setFieldValue(field, fieldValuePrimaryObject.toArray((Object[]) Array
-//				.newInstance(field.getType().getComponentType(), fieldValuePrimaryObject.size())));
-//		    }
-
-		} else if (List.class.isAssignableFrom(fieldType)) {
-
-		    List<Object> fieldValuePrimaryObjectList = (List<Object>) primary.getFieldValue(field);
-		    List<Object> fieldValueSecondaryObjectList = (List<Object>) secondary.getFieldValue(field);
-		    megeList(consilidatedEntity, fieldValuePrimaryObjectList, fieldValueSecondaryObjectList, field);
-
-		} else if (fieldType.isPrimitive() || String.class.isAssignableFrom(fieldType)) {
-		    Object fieldValuePrimaryObjectPrimitiveOrString = primary.getFieldValue(field);
-		    Object fieldValueSecondaryObjectPrimitiveOrString = secondary.getFieldValue(field);
-
-		    if (fieldValuePrimaryObjectPrimitiveOrString == null && fieldValueSecondaryObjectPrimitiveOrString != null) {
-			consilidatedEntity.setFieldValue(field, fieldValueSecondaryObjectPrimitiveOrString);
-		    } else if (fieldValuePrimaryObjectPrimitiveOrString != null) {
-			consilidatedEntity.setFieldValue(field, fieldValuePrimaryObjectPrimitiveOrString);
-		    }
-		    
-		} else if (Date.class.isAssignableFrom(fieldType)) {
-		    Object fieldValuePrimaryObjectDate = primary.getFieldValue(field);
-		    Object fieldValueSecondaryObjectDate = secondary.getFieldValue(field);
-
-		    if (fieldValuePrimaryObjectDate == null && fieldValueSecondaryObjectDate != null) {
-			consilidatedEntity.setFieldValue(field, new Date (((Date)fieldValueSecondaryObjectDate).getTime()));
-		    } else if (fieldValuePrimaryObjectDate != null) {
-			consilidatedEntity.setFieldValue(field, new Date (((Date)fieldValuePrimaryObjectDate).getTime()));
-		    }
-
-		} else if (Map.class.isAssignableFrom(fieldType)) {
-		    extracted(consilidatedEntity, primary, secondary, prefLabelsForAltLabels, field, fieldName);
-
-		} 
-
-	    }
-
-	    mergeSkippedPrefLabels(consilidatedEntity, prefLabelsForAltLabels, allEntityFields);
-	} catch (IllegalArgumentException e) {
-	    logger.error(
-		    "During the reconceliation of the entity data from different sources a method has been passed an illegal or inappropriate argument.",
-		    e);
-	} catch (IllegalAccessException e) {
-	    logger.error(
-		    "During the reconceliation of the entity data from different sources an illegal access to some method or field has happened.",
-		    e);
+	if (europeanaProxy.getProxyIn()!=null) {
+		europeanaProxy.getProxyIn().setModified(new Date());
 	}
-    }
+}
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    void extracted(Entity consilidatedEntity, Entity primary, Entity secondary,
+	private Entity combineEntities(Entity primary, Entity secondary, List<String> fieldsToIgnore)
+			throws EntityCreationException, IllegalAccessException {
+		Entity consolidatedEntity = EntityObjectFactory.createEntityObject(primary.getType());
+
+				/*
+				 * store the preferred label in the secondary entity that is different from the
+				 * preferred label in the primary entity to the alternative labels of the
+				 * consolidated entity
+				 */
+				Map<Object, Object> prefLabelsForAltLabels = new HashMap<>();
+
+				List<Field> allEntityFields = new ArrayList<>();
+				EntityUtils.getAllFields(allEntityFields, primary.getClass());
+
+				for (Field field : allEntityFields) {
+					if (fieldsToIgnore.contains(field.getName())) {
+						continue;
+					}
+
+			Class<?> fieldType = field.getType();
+			String fieldName = field.getName();
+
+			if (fieldType.isArray()) {
+					Object[] mergedArray = mergeArrays(primary, secondary, field);
+				consolidatedEntity.setFieldValue(field, mergedArray);
+
+			} else if (List.class.isAssignableFrom(fieldType)) {
+
+					List<Object> fieldValuePrimaryObjectList = (List<Object>) primary.getFieldValue(field);
+					List<Object> fieldValueSecondaryObjectList = (List<Object>) secondary.getFieldValue(field);
+					megeList(consolidatedEntity, fieldValuePrimaryObjectList, fieldValueSecondaryObjectList, field);
+
+			} else if (fieldType.isPrimitive() || String.class.isAssignableFrom(fieldType)) {
+					Object fieldValuePrimaryObjectPrimitiveOrString = primary.getFieldValue(field);
+					Object fieldValueSecondaryObjectPrimitiveOrString = secondary.getFieldValue(field);
+
+					if (fieldValuePrimaryObjectPrimitiveOrString == null && fieldValueSecondaryObjectPrimitiveOrString != null) {
+						consolidatedEntity.setFieldValue(field, fieldValueSecondaryObjectPrimitiveOrString);
+					} else if (fieldValuePrimaryObjectPrimitiveOrString != null) {
+						consolidatedEntity.setFieldValue(field, fieldValuePrimaryObjectPrimitiveOrString);
+					}
+
+			} else if (Date.class.isAssignableFrom(fieldType)) {
+					Object fieldValuePrimaryObjectDate = primary.getFieldValue(field);
+					Object fieldValueSecondaryObjectDate = secondary.getFieldValue(field);
+
+					if (fieldValuePrimaryObjectDate == null && fieldValueSecondaryObjectDate != null) {
+						consolidatedEntity.setFieldValue(field, new Date (((Date)fieldValueSecondaryObjectDate).getTime()));
+					} else if (fieldValuePrimaryObjectDate != null) {
+						consolidatedEntity.setFieldValue(field, new Date (((Date)fieldValuePrimaryObjectDate).getTime()));
+					}
+
+			} else if (Map.class.isAssignableFrom(fieldType)) {
+					combineEntities(consolidatedEntity, primary, secondary, prefLabelsForAltLabels, field, fieldName);
+
+			}
+
+				}
+
+				mergeSkippedPrefLabels(consolidatedEntity, prefLabelsForAltLabels, allEntityFields);
+
+
+		return consolidatedEntity;
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+    void combineEntities(Entity consilidatedEntity, Entity primary, Entity secondary,
 	    Map<Object, Object> prefLabelsForAltLabels, Field field, String fieldName) throws IllegalAccessException {
 	//TODO: refactor implemetation
 	

--- a/entity-management-web/src/test/resources/content/concept_update.json
+++ b/entity-management-web/src/test/resources/content/concept_update.json
@@ -1,4 +1,5 @@
 {
+  "type": "Concept",
   "prefLabel": {
     "en": "bathtub updated"
   },

--- a/entity-management-web/src/test/resources/content/concept_update.json
+++ b/entity-management-web/src/test/resources/content/concept_update.json
@@ -6,5 +6,8 @@
   "altLabel": {
     "en": [ "bath updated", "tub updated" ]
   },
+  "note": {
+    "en": ["large container for holding water in which a person may bathe"]
+  },
   "depiction": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e8/1rm60rt0t_rtbcwh.jpg/330px-1rm60rt0t_rtbcwh_updated.jpg"
 }


### PR DESCRIPTION
This PR implements changes to correctly handle updates:

-  the request body is deserialized into an Entity POJO; and then
-  metadata in the update are merged with the Europeana proxy entity (with the same logic used for data reconciliation)

Update requests are required to have a `type` field in the request body.