### PR TITLE
EA-2420: Cleanup EntityFieldsCleanerTest

### DIFF
--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/config/AppConfig.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/config/AppConfig.java
@@ -7,7 +7,6 @@ import java.io.InputStreamReader;
 import java.util.stream.Collectors;
 
 import javax.annotation.Resource;
-import javax.validation.ValidatorFactory;
 
 import dev.morphia.Datastore;
 import eu.europeana.entitymanagement.batch.config.MongoBatchConfigurer;
@@ -17,7 +16,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.TaskExecutor;
-import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
@@ -25,8 +23,6 @@ import eu.europeana.api.commons.oauth2.service.impl.EuropeanaClientDetailsServic
 import eu.europeana.entitymanagement.common.config.AppConfigConstants;
 import eu.europeana.entitymanagement.common.config.DataSources;
 import eu.europeana.entitymanagement.common.config.EntityManagementConfiguration;
-import eu.europeana.entitymanagement.common.config.LanguageCodes;
-import eu.europeana.entitymanagement.normalization.EntityFieldsCleaner;
 import org.springframework.web.filter.ShallowEtagHeaderFilter;
 
 /**
@@ -64,26 +60,6 @@ public class AppConfig extends AppConfigConstants{
 	}
     }
 
-    @Bean(name=BEAN_EM_LANGUAGE_CODES)
-    public LanguageCodes getLanguageCodes() throws IOException {
-
-	String languagecodesXMLConfig = emConfiguration.getLanguagecodesXMLConfig();
-	try (InputStream inputStream = getClass().getResourceAsStream(languagecodesXMLConfig);
-		BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
-	    String contents = reader.lines().collect(Collectors.joining(System.lineSeparator()));
-	    return xmlMapper.readValue(contents, LanguageCodes.class);
-	}
-    }
-
-    @Bean(name=BEAN_EM_VALIDATOR_FACTORY)
-    public ValidatorFactory getValidatorFactoryBean() {
-	return new LocalValidatorFactoryBean();
-    }
-    
-    @Bean(name=BEAN_EM_ENTITY_FIELD_CLEANER)
-    public EntityFieldsCleaner getEntityFieldsCleanerBean() throws IOException {
-	return new EntityFieldsCleaner(getLanguageCodes());
-    }
     
     @Bean(name=BEAN_CLIENT_DETAILS_SERVICE)
     public EuropeanaClientDetailsService getClientDetailsService() {

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/config/ValidatorConfig.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/config/ValidatorConfig.java
@@ -1,0 +1,58 @@
+package eu.europeana.entitymanagement.config;
+
+import static eu.europeana.entitymanagement.common.config.AppConfigConstants.BEAN_EM_ENTITY_FIELD_CLEANER;
+import static eu.europeana.entitymanagement.common.config.AppConfigConstants.BEAN_EM_LANGUAGE_CODES;
+import static eu.europeana.entitymanagement.common.config.AppConfigConstants.BEAN_EM_VALIDATOR_FACTORY;
+import static eu.europeana.entitymanagement.common.config.AppConfigConstants.BEAN_XML_MAPPER;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import eu.europeana.entitymanagement.common.config.EntityManagementConfiguration;
+import eu.europeana.entitymanagement.common.config.LanguageCodes;
+import eu.europeana.entitymanagement.normalization.EntityFieldsCleaner;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+import javax.validation.ValidatorFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+@Configuration
+public class ValidatorConfig {
+
+  private final XmlMapper xmlMapper;
+  private final EntityManagementConfiguration emConfiguration;
+
+  @Autowired
+  public ValidatorConfig(@Qualifier(BEAN_XML_MAPPER) XmlMapper xmlMapper,
+      EntityManagementConfiguration emConfiguration) {
+    this.xmlMapper = xmlMapper;
+    this.emConfiguration = emConfiguration;
+  }
+
+  @Bean(name=BEAN_EM_VALIDATOR_FACTORY)
+  public ValidatorFactory getValidatorFactoryBean() {
+    return new LocalValidatorFactoryBean();
+  }
+
+  @Bean(name=BEAN_EM_ENTITY_FIELD_CLEANER)
+  public EntityFieldsCleaner getEntityFieldsCleanerBean() throws IOException {
+    return new EntityFieldsCleaner(getLanguageCodes());
+  }
+
+  @Bean(name=BEAN_EM_LANGUAGE_CODES)
+  public LanguageCodes getLanguageCodes() throws IOException {
+    String languagecodesXMLConfig = emConfiguration.getLanguagecodesXMLConfig();
+    try (InputStream inputStream = getClass().getResourceAsStream(languagecodesXMLConfig)) {
+      assert inputStream != null;
+      try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+        String contents = reader.lines().collect(Collectors.joining(System.lineSeparator()));
+        return xmlMapper.readValue(contents, LanguageCodes.class);
+      }
+    }
+  }
+}

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/MetisDereferenceUtils.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/MetisDereferenceUtils.java
@@ -1,0 +1,60 @@
+package eu.europeana.entitymanagement.web;
+
+import eu.europeana.api.commons.error.EuropeanaApiException;
+import eu.europeana.entitymanagement.definitions.model.Entity;
+import eu.europeana.entitymanagement.web.xml.model.XmlBaseEntityImpl;
+import eu.europeana.entitymanagement.web.xml.model.metis.EnrichmentResultList;
+import java.io.StringReader;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+
+public class MetisDereferenceUtils {
+  private static final Object deserializerLock = new Object();
+  private static Unmarshaller jaxbDeserializer;
+
+  /**
+   * Unmarshalls Metis dereference response into an Entity
+   * @param id entity ID
+   * @param metisResponseBody XML response body from Metis
+   * @return Entity implementation
+   * @throws EuropeanaApiException on error
+   */
+  public static Entity parseMetisResponse(String id, String metisResponseBody)
+      throws EuropeanaApiException {
+    EnrichmentResultList derefResult;
+    /*
+     * Prevent "FWK005 parse may not be called while parsing" error when this method
+     * is called by multiple threads
+     **/
+    synchronized (deserializerLock) {
+      try {
+        derefResult = (EnrichmentResultList) getDeserializer().unmarshal(new StringReader(metisResponseBody));
+      } catch (JAXBException | RuntimeException e) {
+        throw new EuropeanaApiException(
+            "Unexpected exception occurred when parsing metis dereference response for entity:  " + id, e);
+      }
+    }
+
+    if (derefResult == null || derefResult.getEnrichmentBaseResultWrapperList().isEmpty()
+        || derefResult.getEnrichmentBaseResultWrapperList().get(0).getEnrichmentBaseList().isEmpty()) {
+      // Metis returns an empty XML response if de-referencing is unsuccessful,
+      // instead of throwing an error
+      return null;
+    }
+
+    XmlBaseEntityImpl xmlBaseEntity = derefResult.getEnrichmentBaseResultWrapperList().get(0)
+        .getEnrichmentBaseList().get(0);
+
+    return xmlBaseEntity.toEntityModel();
+  }
+
+  private static Unmarshaller getDeserializer() throws JAXBException {
+    if (jaxbDeserializer == null) {
+      JAXBContext jaxbContext = JAXBContext.newInstance(EnrichmentResultList.class);
+      jaxbDeserializer = jaxbContext.createUnmarshaller();
+    }
+    return jaxbDeserializer;
+  }
+
+}

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/service/MetisDereferenceService.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/service/MetisDereferenceService.java
@@ -4,10 +4,7 @@ import eu.europeana.api.commons.error.EuropeanaApiException;
 import eu.europeana.entitymanagement.common.config.EntityManagementConfiguration;
 import eu.europeana.entitymanagement.config.AppConfig;
 import eu.europeana.entitymanagement.definitions.model.Entity;
-import eu.europeana.entitymanagement.exception.EntityCreationException;
 import eu.europeana.entitymanagement.exception.HttpBadRequestException;
-import eu.europeana.entitymanagement.web.xml.model.XmlBaseEntityImpl;
-import eu.europeana.entitymanagement.web.xml.model.metis.EnrichmentResultList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,12 +13,8 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
-import java.io.StringReader;
-
 import static eu.europeana.entitymanagement.common.config.AppConfigConstants.METIS_DEREF_PATH;
+import static eu.europeana.entitymanagement.web.MetisDereferenceUtils.parseMetisResponse;
 
 /**
  * Handles de-referencing entities from Metis.
@@ -29,10 +22,6 @@ import static eu.europeana.entitymanagement.common.config.AppConfigConstants.MET
 @Service(AppConfig.BEAN_METIS_DEREF_SERVICE)
 public class MetisDereferenceService {
     private static final Logger logger = LogManager.getLogger(MetisDereferenceService.class);
-
-    private Unmarshaller jaxbDeserializer;
-    private final Object deserializerLock = new Object();
-
 
 	private final WebClient metisWebClient;
 
@@ -47,39 +36,13 @@ public class MetisDereferenceService {
      * @param id external ID for entity
      * @return An optional containing the de-referenced entity, or an empty optional
      *         if no match found.
-     * @throws EntityCreationException
+     * @throws EuropeanaApiException on error
      */
     public Entity dereferenceEntityById(String id) throws EuropeanaApiException {
 	String metisResponseBody = fetchMetisResponse(id);
 	return parseMetisResponse(id, metisResponseBody);
     }
 
-    public Entity parseMetisResponse(String id, String metisResponseBody)
-	    throws EuropeanaApiException, EntityCreationException {
-	EnrichmentResultList derefResult;
-	// Prevent "FWK005 parse may not be called while parsing" error when this method
-	// is called by multiple threads
-	synchronized (deserializerLock) {
-	    try {
-		derefResult = (EnrichmentResultList) getDeserializer().unmarshal(new StringReader(metisResponseBody));
-	    } catch (JAXBException | RuntimeException e) {
-		throw new EuropeanaApiException(
-			"Unexpected exception occurred when parsing metis dereference response for entity:  " + id, e);
-	    }
-	}
-
-	if (derefResult == null || derefResult.getEnrichmentBaseResultWrapperList().isEmpty()
-		|| derefResult.getEnrichmentBaseResultWrapperList().get(0).getEnrichmentBaseList().isEmpty()) {
-	    // Metis returns an empty XML response if de-referencing is unsuccessful,
-	    // instead of throwing an error
-	    return null;
-	}
-
-	XmlBaseEntityImpl xmlBaseEntity = derefResult.getEnrichmentBaseResultWrapperList().get(0)
-		.getEnrichmentBaseList().get(0);
-
-	return xmlBaseEntity.toEntityModel();
-    }
 
     String fetchMetisResponse(String entityId) {
 	logger.debug("De-referencing entityId={} from Metis", entityId);
@@ -100,12 +63,6 @@ public class MetisDereferenceService {
     }
 
 
-	private Unmarshaller getDeserializer() throws JAXBException {
-		if (jaxbDeserializer == null) {
-			JAXBContext jaxbContext = JAXBContext.newInstance(EnrichmentResultList.class);
-			jaxbDeserializer = jaxbContext.createUnmarshaller();
-		}
-		return jaxbDeserializer;
-	}
+
 
 }

--- a/entity-management-web/src/test/java/eu/europeana/entitymanagement/validation/EntityFieldsCleanerTest.java
+++ b/entity-management-web/src/test/java/eu/europeana/entitymanagement/validation/EntityFieldsCleanerTest.java
@@ -3,49 +3,37 @@ package eu.europeana.entitymanagement.validation;
 import static eu.europeana.entitymanagement.testutils.BaseMvcTestUtils.loadFile;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import eu.europeana.entitymanagement.common.config.EntityManagementConfiguration;
+import eu.europeana.entitymanagement.config.SerializationConfig;
+import eu.europeana.entitymanagement.config.ValidatorConfig;
+import eu.europeana.entitymanagement.web.MetisDereferenceUtils;
 import java.io.IOException;
-
-import javax.annotation.Resource;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import eu.europeana.api.commons.error.EuropeanaApiException;
-import eu.europeana.entitymanagement.common.config.AppConfigConstants;
 import eu.europeana.entitymanagement.common.config.LanguageCodes;
-import eu.europeana.entitymanagement.config.AppConfig;
 import eu.europeana.entitymanagement.definitions.model.Agent;
-import eu.europeana.entitymanagement.exception.EntityCreationException;
 import eu.europeana.entitymanagement.normalization.EntityFieldsCleaner;
 import eu.europeana.entitymanagement.testutils.BaseMvcTestUtils;
-import eu.europeana.entitymanagement.web.service.MetisDereferenceService;
 
-@SpringBootTest
+@SpringBootTest(classes = {ValidatorConfig.class,
+    SerializationConfig.class, EntityManagementConfiguration.class})
 public class EntityFieldsCleanerTest {
-
-    @Qualifier(AppConfigConstants.BEAN_JSON_MAPPER)
+    
     @Autowired
-    private ObjectMapper objectMapper;
-    
-    @Resource(name = "emLanguageCodes")
-    LanguageCodes emLanguageCodes;
-    
-    @Resource(name = AppConfig.BEAN_METIS_DEREF_SERVICE)
-    MetisDereferenceService metisDerefService;
+    private LanguageCodes emLanguageCodes;
+
     
     @Test
-    public void shoudCleanEntityFields() throws JsonMappingException, JsonProcessingException, IOException, EntityCreationException, EuropeanaApiException {
-        // read the test data for the Concept entity from the file
-//        ConceptImpl concept = objectMapper.readValue(loadFile(CONCEPT_VALIDATE_FIELDS_JSON), ConceptImpl.class);
-	Agent agent = (Agent) metisDerefService.parseMetisResponse("http://www.wikidata.org/entity/Q855", loadFile(BaseMvcTestUtils.AGENT_STALIN_XML)); 
+    public void shouldCleanEntityFields() throws IOException, EuropeanaApiException {
+	Agent agent = (Agent) MetisDereferenceUtils
+      .parseMetisResponse("http://www.wikidata.org/entity/Q855", loadFile(BaseMvcTestUtils.AGENT_STALIN_XML));
 	
         EntityFieldsCleaner fieldCleaner = new EntityFieldsCleaner(emLanguageCodes);
+        assert agent != null;
         fieldCleaner.cleanAndNormalize(agent);
         
         assertEquals(24, agent.getPrefLabel().size());


### PR DESCRIPTION
Follows up #57.

Load required configuration classes for test, instead of the entire application context
