### PR TITLE
EA-2574: Improve entity update scheduling 

### DIFF
--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/web/EntityIdDisabledStatus.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/web/EntityIdDisabledStatus.java
@@ -1,0 +1,41 @@
+package eu.europeana.entitymanagement.definitions.web;
+
+/**
+ * Container class for EntityIds - Disabled status
+ */
+public class EntityIdDisabledStatus {
+
+    private String entityId;
+    private boolean isDisabled;
+
+    public EntityIdDisabledStatus(String entityId, boolean isDisabled) {
+        this.entityId = entityId;
+        this.isDisabled = isDisabled;
+    }
+
+    public String getEntityId() {
+        return entityId;
+    }
+
+    public boolean isDisabled() {
+        return isDisabled;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        EntityIdDisabledStatus that = (EntityIdDisabledStatus) o;
+
+        if (isDisabled() != that.isDisabled()) return false;
+        return getEntityId().equals(that.getEntityId());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getEntityId().hashCode();
+        result = 31 * result + (isDisabled() ? 1 : 0);
+        return result;
+    }
+}

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/web/EntityIdResponse.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/web/EntityIdResponse.java
@@ -8,11 +8,13 @@ public class EntityIdResponse {
 
     private long expected;
     private List<String> successful;
+    private List<String> skipped;
     private List<String> failed;
 
-    public EntityIdResponse(long expected, List<String> successful, List<String> failed) {
+    public EntityIdResponse(long expected, List<String> successful, List<String> failed, List<String> skipped) {
         this.expected = expected;
         this.successful = successful;
+        this.skipped = skipped;
         this.failed = failed;
     }
 
@@ -20,23 +22,15 @@ public class EntityIdResponse {
         return expected;
     }
 
-    public void setExpected(long expected) {
-        this.expected = expected;
-    }
-
     public List<String> getSuccessful() {
         return successful;
-    }
-
-    public void setSuccessful(List<String> successful) {
-        this.successful = successful;
     }
 
     public List<String> getFailed() {
         return failed;
     }
 
-    public void setFailed(List<String> failed) {
-        this.failed = failed;
+    public List<String> getSkipped() {
+        return skipped;
     }
 }

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/EMController.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/EMController.java
@@ -12,6 +12,7 @@ import eu.europeana.entitymanagement.common.config.EntityManagementConfiguration
 import eu.europeana.entitymanagement.definitions.model.Aggregation;
 import eu.europeana.entitymanagement.definitions.model.Entity;
 import eu.europeana.entitymanagement.definitions.model.EntityRecord;
+import eu.europeana.entitymanagement.definitions.web.EntityIdDisabledStatus;
 import eu.europeana.entitymanagement.definitions.web.EntityIdResponse;
 import eu.europeana.entitymanagement.exception.EntityMismatchException;
 import eu.europeana.entitymanagement.exception.EntityRemovedException;
@@ -36,12 +37,15 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static eu.europeana.entitymanagement.solr.SolrUtils.createSolrEntity;
 import static eu.europeana.entitymanagement.vocabulary.WebEntityConstants.QUERY_PARAM_QUERY;
+import static java.util.stream.Collectors.groupingBy;
 
 
 @RestController
@@ -216,13 +220,7 @@ public class EMController extends BaseRest {
 			throw new HttpBadRequestException(INVALID_UPDATE_REQUEST_MSG);
 		}
 
-		List<String> existingEntityIds = entityRecordService.retrieveMultipleByEntityId(entityIds);
-		// get entityIds in request that weren't retrieved from db
-		List<String> failures = entityIds.stream().filter(e -> !existingEntityIds.contains(e))
-				.collect(Collectors.toList());
-
-		entityUpdateService.scheduleUpdates(existingEntityIds, BatchUpdateType.FULL);
-		return  ResponseEntity.accepted().body(new EntityIdResponse(entityIds.size(), existingEntityIds, failures));
+		return scheduleBatchUpdates(request, entityIds, BatchUpdateType.FULL);
 	}
 
 
@@ -248,13 +246,7 @@ public class EMController extends BaseRest {
 			throw new HttpBadRequestException(INVALID_UPDATE_REQUEST_MSG);
 		}
 
-		List<String> existingEntityIds = entityRecordService.retrieveMultipleByEntityId(entityIds);
-		List<String> failures = entityIds.stream()
-				.filter(e -> !existingEntityIds.contains(e))
-				.collect(Collectors.toList());
-
-		entityUpdateService.scheduleUpdates(existingEntityIds, BatchUpdateType.METRICS);
-		return  ResponseEntity.accepted().body(new EntityIdResponse(entityIds.size(), existingEntityIds, failures));
+		return scheduleBatchUpdates(request, entityIds, BatchUpdateType.METRICS);
 	}
 
 	@ApiOperation(value = "Retrieve a known entity", nickname = "getEntityJsonLd", response = java.lang.Void.class)
@@ -433,6 +425,56 @@ public class EMController extends BaseRest {
 					.build();
 		}
 		return null;
+	}
+
+	private ResponseEntity<EntityIdResponse> scheduleBatchUpdates(HttpServletRequest request, List<String> entityIds, BatchUpdateType updateType) {
+		// Get all existing EntityIds and their disabled status
+		List<EntityIdDisabledStatus> statusList = entityRecordService
+				.retrieveMultipleByEntityId(entityIds, false);
+
+		// extract only the entityIds for easy comparison
+		List<String> existingEntityIds = statusList.stream()
+				.map(EntityIdDisabledStatus::getEntityId)
+				.collect(Collectors.toList());
+
+		// failures are entityIds that weren't retrieved
+		List<String> failures = entityIds.stream()
+				.filter(e -> !existingEntityIds.contains(e))
+				.collect(Collectors.toList());
+
+		Map<Boolean, List<EntityIdDisabledStatus>> entityIdsByDisabled = statusList.stream()
+				.collect(groupingBy(EntityIdDisabledStatus::isDisabled));
+
+		// get entityIds that can be scheduled (disabled = false)
+		List<EntityIdDisabledStatus> nonDisabledEntitites = entityIdsByDisabled.get(false);
+		List<String> toBeScheduled;
+
+		if (CollectionUtils.isEmpty(nonDisabledEntitites)) {
+			toBeScheduled = Collections.emptyList();
+		} else {
+			toBeScheduled = nonDisabledEntitites.stream()
+					.map(EntityIdDisabledStatus::getEntityId).collect(Collectors.toList());
+		}
+
+
+		// updates skipped if disabled=true
+		List<EntityIdDisabledStatus> disabledEntities = entityIdsByDisabled.get(true);
+		List<String> skippedEntities;
+		if(CollectionUtils.isEmpty(disabledEntities)){
+			skippedEntities = Collections.emptyList();
+		} else {
+			skippedEntities = disabledEntities.stream()
+				.map(EntityIdDisabledStatus::getEntityId).collect(Collectors.toList());
+		}
+
+		entityUpdateService.scheduleUpdates(toBeScheduled, updateType);
+
+		// set required headers for this endpoint
+		org.springframework.http.HttpHeaders httpHeaders = createAllowHeader(request);
+		httpHeaders.add(HttpHeaders.CONTENT_TYPE, HttpHeaders.CONTENT_TYPE_JSONLD_UTF8);
+		return ResponseEntity.accepted().headers(httpHeaders).body(
+				new EntityIdResponse(entityIds.size(), toBeScheduled, failures, skippedEntities)
+		);
 	}
 
 	private void launchUpdateTask(String entityId)

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/EnrichmentController.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/EnrichmentController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -105,6 +106,6 @@ public class EnrichmentController extends BaseRest{
       if (!entityList.isEmpty()) {
           failed = entityList;
       }
-      return  new EntityIdResponse(expected, successful, failed);
+      return  new EntityIdResponse(expected, successful, failed, Collections.emptyList());
     }
 }

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/service/EntityRecordService.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/service/EntityRecordService.java
@@ -8,6 +8,7 @@ import eu.europeana.entitymanagement.common.config.EntityManagementConfiguration
 import eu.europeana.entitymanagement.config.AppConfig;
 import eu.europeana.entitymanagement.definitions.exceptions.EntityCreationException;
 import eu.europeana.entitymanagement.definitions.model.*;
+import eu.europeana.entitymanagement.definitions.web.EntityIdDisabledStatus;
 import eu.europeana.entitymanagement.exception.EntityAlreadyExistsException;
 import eu.europeana.entitymanagement.exception.EntityNotFoundException;
 import eu.europeana.entitymanagement.exception.EntityRemovedException;
@@ -78,8 +79,8 @@ public class EntityRecordService {
 	}
 
 
-    public List<String> retrieveMultipleByEntityId(List<String> entityIds){
-			return entityRecordRepository.getExistingEntityIds(entityIds);
+    public List<EntityIdDisabledStatus> retrieveMultipleByEntityId(List<String> entityIds, boolean excludeDisabled){
+			return entityRecordRepository.getEntityIds(entityIds, excludeDisabled);
 		}
     /**
      * Gets coreferenced entity with the given id (sameAs or exactMatch value in the


### PR DESCRIPTION
- return disabled entities as "skipped" instead of "failures"
- set required response headers