### PR TITLE
EA-2635: Properly handle issues with Metis dereferencing

### DIFF
--- a/entity-management-web/src/integration-test/java/eu/europeana/entitymanagement/web/EntityRegistrationIT.java
+++ b/entity-management-web/src/integration-test/java/eu/europeana/entitymanagement/web/EntityRegistrationIT.java
@@ -169,12 +169,12 @@ public class EntityRegistrationIT extends BaseWebControllerTest {
     }
 
     @Test
-    public void registrationWithEmptyMetisResponseShouldReturn500() throws Exception {
+    public void registrationWithEmptyMetisResponseShouldReturn400() throws Exception {
         // mockMetis returns an empty response body for this entity
         String europeanaMetadata = loadFile(CONCEPT_REGISTER_UNKNOWN_ENTITY);
         mockMvc.perform(post(BASE_SERVICE_URL)
                 .content(europeanaMetadata)
                 .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().is5xxServerError());
+                .andExpect(status().isBadRequest());
     }
 }

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/batch/processor/EntityDereferenceProcessor.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/batch/processor/EntityDereferenceProcessor.java
@@ -17,7 +17,6 @@ import eu.europeana.entitymanagement.definitions.model.EntityRecord;
 import eu.europeana.entitymanagement.exception.EntityMismatchException;
 import eu.europeana.entitymanagement.exception.DatasourceNotKnownException;
 import eu.europeana.entitymanagement.utils.EntityComparator;
-import eu.europeana.entitymanagement.web.service.MetisDereferenceService;
 
 /**
  * This {@link ItemProcessor} retrieves Entity metadata from Metis, and then overwrites the local

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/exception/DatasourceDereferenceException.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/exception/DatasourceDereferenceException.java
@@ -4,16 +4,16 @@ import eu.europeana.api.commons.error.EuropeanaApiException;
 import org.springframework.http.HttpStatus;
 
 /**
- * Exception thrown when an invalid response is received from Metis.
+ * Exception thrown when an invalid response is received from external datasource.
  *
  * {@link DatasourceNotKnownException} should be used if the response is valid but empty (equivalent to HTTP 404 status code)
  */
-public class MetisDereferenceError extends EuropeanaApiException {
-    public MetisDereferenceError(String msg) {
+public class DatasourceDereferenceException extends EuropeanaApiException {
+    public DatasourceDereferenceException(String msg) {
         super(msg);
     }
 
-    public MetisDereferenceError(String msg, Throwable t) {
+    public DatasourceDereferenceException(String msg, Throwable t) {
         super(msg, t);
     }
 

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/exception/DatasourceNotKnownException.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/exception/DatasourceNotKnownException.java
@@ -1,9 +1,11 @@
 package eu.europeana.entitymanagement.exception;
 
 import eu.europeana.api.commons.error.EuropeanaApiException;
+import org.springframework.http.HttpStatus;
 
 /**
- * Exception thrown during de-referenciation, if datasource returns an empty response
+ * Exception thrown during de-referenciation, if datasource returns an empty response, or 404 response.
+ * Considered to be caused by a bad user request.
  */
 public class DatasourceNotKnownException extends EuropeanaApiException {
     public DatasourceNotKnownException(String message) {
@@ -18,5 +20,10 @@ public class DatasourceNotKnownException extends EuropeanaApiException {
     @Override
     public boolean doLogStacktrace() {
         return false;
+    }
+
+    @Override
+    public HttpStatus getResponseStatus() {
+        return HttpStatus.BAD_REQUEST;
     }
 }

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/exception/DatasourceNotReachableException.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/exception/DatasourceNotReachableException.java
@@ -1,0 +1,29 @@
+package eu.europeana.entitymanagement.exception;
+
+import eu.europeana.api.commons.error.EuropeanaApiException;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Exception thrown during dereferencing when external datasource is down
+ */
+public class DatasourceNotReachableException extends EuropeanaApiException {
+
+  public DatasourceNotReachableException(String msg) {
+    super(msg);
+  }
+
+  @Override
+  public boolean doLog() {
+    return true;
+  }
+
+  @Override
+  public boolean doLogStacktrace() {
+    return false;
+  }
+
+  @Override
+  public HttpStatus getResponseStatus() {
+    return HttpStatus.GATEWAY_TIMEOUT;
+  }
+}

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/EMController.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/EMController.java
@@ -28,7 +28,6 @@ import eu.europeana.entitymanagement.vocabulary.WebEntityConstants;
 import eu.europeana.entitymanagement.web.model.EntityPreview;
 import eu.europeana.entitymanagement.web.service.DereferenceServiceLocator;
 import eu.europeana.entitymanagement.web.service.EntityRecordService;
-import eu.europeana.entitymanagement.web.service.MetisDereferenceService;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/MetisDereferenceUtils.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/MetisDereferenceUtils.java
@@ -1,7 +1,7 @@
 package eu.europeana.entitymanagement.web;
 
 import eu.europeana.api.commons.error.EuropeanaApiException;
-import eu.europeana.entitymanagement.exception.MetisDereferenceError;
+import eu.europeana.entitymanagement.exception.DatasourceDereferenceException;
 import eu.europeana.entitymanagement.web.xml.model.XmlBaseEntityImpl;
 import eu.europeana.entitymanagement.web.xml.model.metis.EnrichmentResultList;
 
@@ -26,7 +26,7 @@ public class MetisDereferenceUtils {
       try {
         derefResult = (EnrichmentResultList) unmarshaller.unmarshal(new StringReader(metisResponseBody));
       } catch (JAXBException | RuntimeException e) {
-        throw new MetisDereferenceError(
+        throw new DatasourceDereferenceException(
             String.format("Error while deserializing metis dereference response for uri '%s'", id), e);
       }
 
@@ -46,7 +46,7 @@ public class MetisDereferenceUtils {
             .filter(e -> id.equals(e.getAbout())).findFirst();
 
     if(entityOptional.isEmpty()){
-      throw new MetisDereferenceError(String.format("No match in Metis dereference response for uri '%s'", id));
+      throw new DatasourceDereferenceException(String.format("No match in Metis dereference response for uri '%s'", id));
     }
 
     return entityOptional.get();

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/service/MetisDereferenceService.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/service/MetisDereferenceService.java
@@ -111,7 +111,7 @@ public class MetisDereferenceService implements InitializingBean, Dereferencer {
 			}
 			// thrown if DNS lookup for Metis dereference url fails
 			catch (WebClientRequestException we) {
-				throw new DatasourceNotReachableException("Metis Dereference Service");
+				throw new DatasourceNotReachableException("Metis Dereference Service is not reachable");
 			}
 			catch (Exception e){
 				/*


### PR DESCRIPTION
Depends on changes in #125 

- 400 Bad Request returned if dereference lookup fails
- 504 Gateway Timeout returned if dereference service cannot be reached