### PR TITLE
EA-2656: Improve handling of coref

### DIFF
--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/Agent.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/Agent.java
@@ -1,48 +1,17 @@
 package eu.europeana.entitymanagement.definitions.model;
 
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.ALT_LABEL;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.BEGIN;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.BIOGRAPHICAL_INFORMATION;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.CONTEXT;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.DATE;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.DATE_OF_BIRTH;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.DATE_OF_DEATH;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.DATE_OF_ESTABLISHMENT;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.DATE_OF_TERMINATION;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.DEPICTION;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.END;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.GENDER;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.HAS_MET;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.HAS_PART;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.HIDDEN_LABEL;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.ID;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.IDENTIFIER;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.IS_PART_OF;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.IS_RELATED_TO;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.IS_SHOWN_BY;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.NAME;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.NOTE;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.PLACE_OF_BIRTH;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.PLACE_OF_DEATH;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.PREF_LABEL;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.PROFESSION_OR_OCCUPATION;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.SAME_AS;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.TYPE;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.WAS_PRESENT_AT;
-
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.*;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSetter;
-
 import eu.europeana.entitymanagement.vocabulary.EntityTypes;
-import eu.europeana.entitymanagement.vocabulary.WebEntityFields;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 @JsonPropertyOrder({CONTEXT, ID, TYPE, DEPICTION, IS_SHOWN_BY, PREF_LABEL, ALT_LABEL, HIDDEN_LABEL, NAME, BEGIN, DATE_OF_BIRTH, DATE_OF_ESTABLISHMENT,
@@ -67,7 +36,6 @@ public class Agent extends Entity {
 		this.dateOfEstablishment = copy.getDateOfEstablishment();
 		this.dateOfTermination = copy.getDateOfTermination();
 		this.gender = copy.getGender();
-		if(copy.getExactMatch()!=null) this.exactMatch = new ArrayList<>(copy.getExactMatch());
 	}
 
 	public Agent() {
@@ -93,7 +61,7 @@ public class Agent extends Entity {
 	private String dateOfTermination; // format "YYYY"
 	private String gender;
 
-	private List<String> exactMatch;
+	private List<String> sameAs;
 
 	@JsonGetter(WAS_PRESENT_AT)
 	public List<String> getWasPresentAt() {
@@ -245,14 +213,6 @@ public class Agent extends Entity {
 		this.professionOrOccupation = professionOrOccupation;
 	}
 
-	public List<String> getExactMatch() {
-		return exactMatch;
-	}
-
-	public void setExactMatch(List<String> exactMatch) {
-		this.exactMatch = exactMatch;
-	}
-
 
 	public String getType() {
 		return EntityTypes.Agent.getEntityType();
@@ -270,4 +230,15 @@ public class Agent extends Entity {
 		field.set(this, value);
 	}
 
+	@Override
+	@JsonSetter(SAME_AS)
+	public void setSameReferenceLinks(List<String> uris) {
+		this.sameAs = uris;
+	}
+
+	@Override
+	@JsonGetter(SAME_AS)
+	public List<String> getSameReferenceLinks() {
+		return this.sameAs;
+	}
 }

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/Concept.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/Concept.java
@@ -1,37 +1,17 @@
 package eu.europeana.entitymanagement.definitions.model;
 
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.ALT_LABEL;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.BROADER;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.BROAD_MATCH;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.CLOSE_MATCH;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.CONTEXT;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.DEPICTION;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.EXACT_MATCH;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.HIDDEN_LABEL;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.ID;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.IN_SCHEME;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.IS_SHOWN_BY;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.NARROWER;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.NARROW_MATCH;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.NOTATION;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.NOTE;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.PREF_LABEL;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.RELATED;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.RELATED_MATCH;
-import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.TYPE;
-
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.*;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSetter;
-
 import eu.europeana.entitymanagement.vocabulary.EntityTypes;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 @JsonPropertyOrder({CONTEXT, ID, TYPE, DEPICTION, IS_SHOWN_BY, PREF_LABEL, ALT_LABEL, HIDDEN_LABEL,NOTE,
@@ -49,7 +29,6 @@ public class Concept extends Entity {
 		if(copy.getRelated()!=null) this.related = new ArrayList<>(copy.getRelated());
 		if(copy.getBroadMatch()!=null) this.broadMatch = new ArrayList<>(copy.getBroadMatch());
 		if(copy.getNarrowMatch()!=null) this.narrowMatch = new ArrayList<>(copy.getNarrowMatch());
-		if(copy.getExactMatch()!=null) this.exactMatch = new ArrayList<>(copy.getExactMatch());
 		if(copy.getCoref()!=null) this.coref = new ArrayList<>(copy.getCoref());
 		if(copy.getRelatedMatch()!=null) this.relatedMatch = new ArrayList<>(copy.getRelatedMatch());
 		if(copy.getCloseMatch()!=null) this.closeMatch = new ArrayList<>(copy.getCloseMatch());
@@ -123,17 +102,6 @@ public class Concept extends Entity {
 		this.narrowMatch = narrowMatch;
 	}
 
-	@JsonGetter(EXACT_MATCH)
-	public List<String> getExactMatch() {
-		return exactMatch;
-	}
-
-	
-	@JsonSetter(EXACT_MATCH)
-	public void setExactMatch(List<String> exactMatch) {
-		this.exactMatch = exactMatch;
-	}
-
 	public List<String> getCoref() {
 		return coref;
 	}
@@ -204,4 +172,15 @@ public class Concept extends Entity {
 		field.set(this, value);
 	}
 
+	@Override
+	@JsonSetter(EXACT_MATCH)
+	public void setSameReferenceLinks(List<String> uris) {
+		this.exactMatch = uris;
+	}
+
+	@Override
+	@JsonGetter(EXACT_MATCH)
+	public List<String> getSameReferenceLinks() {
+		return this.exactMatch;
+	}
 }

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/Entity.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/Entity.java
@@ -16,6 +16,8 @@ import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.DEPICTION
 import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.SAME_AS;
 import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.IS_SHOWN_BY;
 import static eu.europeana.entitymanagement.vocabulary.WebEntityFields.IS_AGGREGATED_BY;
+
+import eu.europeana.entitymanagement.vocabulary.EntityTypes;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -63,6 +65,11 @@ public abstract class Entity {
 	}
 	
 	public Entity(Entity copy) {
+
+		if (!copy.getType().equals(getType())) {
+			throw new IllegalArgumentException("Cannot copy " + copy.getType() + " into " + getType());
+		}
+
 		this.type = copy.getType();
 		this.entityId = copy.getEntityId();
 		this.depiction = copy.getDepiction();
@@ -71,7 +78,7 @@ public abstract class Entity {
 		if(copy.getAltLabel()!=null) this.altLabel = new HashMap<>(copy.getAltLabel());
 		if(copy.getHiddenLabel()!=null) this.hiddenLabel = new HashMap<>(copy.getHiddenLabel());
 		if(copy.getIdentifier()!=null) this.identifier = new ArrayList<>(copy.getIdentifier());
-		if(copy.getSameAs()!=null) this.sameAs = new ArrayList<>(copy.getSameAs());
+		if(copy.getSameReferenceLinks()!=null) this.setSameReferenceLinks(new ArrayList<>(copy.getSameReferenceLinks()));
 		if(copy.getIsRelatedTo()!=null) this.isRelatedTo = new ArrayList<>(copy.getIsRelatedTo());
 		if(copy.getHasPart()!=null) this.hasPart = new ArrayList<>(copy.getHasPart());
 		if(copy.getIsPartOfArray()!=null) this.isPartOf = new ArrayList<>(copy.getIsPartOfArray());
@@ -93,7 +100,6 @@ public abstract class Entity {
 	protected Map<String, List<String>> hiddenLabel;
 
 	protected List<String> identifier;
-	protected List<String> sameAs;
 	protected List<String> isRelatedTo;
 
 	// hierarchical structure available only for a part of entities. Add set/get
@@ -245,18 +251,6 @@ public abstract class Entity {
 		this.depiction = depiction;
 	}
 
-
-	@JsonGetter(SAME_AS)
-	public List<String> getSameAs() {
-		return sameAs;
-	}
-
-
-	@JsonSetter(SAME_AS)
-	public void setSameAs(List<String> sameAs) {
-		this.sameAs = sameAs;
-	}
-
 	@Deprecated
 	public ObjectId getId() {
 		// TODO Auto-generated method stub
@@ -268,17 +262,6 @@ public abstract class Entity {
 	@JsonIgnore
 	public void setId(ObjectId id) {
 		// TODO Auto-generated method stub
-	}
-
-	@Deprecated
-	@JsonIgnore
-	public void setOwlSameAs(List<String> owlSameAs) {
-		setSameAs(sameAs);
-
-	}
-
-	public List<String> getOwlSameAs() {
-		return getSameAs();
 	}
 
 
@@ -354,4 +337,18 @@ public abstract class Entity {
 				entry -> Collections.singletonList(entry.getValue()))
 		);
 	}
+
+	/**
+	 * Gets list of URIs that refer to the same entity. For {@link Concept}, this is the
+	 * skos:ExactMatch. For all other entity types, this is owl:sameAs.
+	 */
+	public abstract List<String> getSameReferenceLinks();
+
+	/**
+	 * Sets list of URIs that refer to the same entity. For {@link Concept}, this is the
+	 * skos:ExactMatch. For all other entity types, this is owl:sameAs.
+	 *
+	 * @param uris List of entity uris
+	 */
+	public abstract void setSameReferenceLinks(List<String> uris);
 }

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/Organization.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/Organization.java
@@ -92,6 +92,8 @@ public class Organization extends Entity {
 	private String postBox;
 	private String hasGeo;
 	private Address address;
+
+	private List<String> sameAs;
 	
 	@JsonGetter(DESCRIPTION)
 	public Map<String, String> getDescription() {
@@ -319,5 +321,17 @@ public class Organization extends Entity {
 
 	public void setAddress(Address address) {
 		this.address = address;
+	}
+
+	@Override
+	@JsonSetter(SAME_AS)
+	public void setSameReferenceLinks(List<String> uris) {
+		this.sameAs = uris;
+	}
+
+	@Override
+	@JsonGetter(SAME_AS)
+	public List<String> getSameReferenceLinks() {
+		return this.sameAs;
 	}
 }

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/Place.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/Place.java
@@ -43,7 +43,6 @@ public class Place extends Entity {
 		this.latitude = copy.getLatitude();
 		this.longitude = copy.getLongitude();
 		this.altitude = copy.getAltitude();
-		if(copy.getExactMatch()!=null) this.exactMatch = new ArrayList<>(copy.getExactMatch());
 	}
 
 
@@ -54,7 +53,7 @@ public class Place extends Entity {
 
 	private List<String> isNextInSequence;
 	private Float latitude, longitude, altitude;
-	private List<String> exactMatch;
+	private List<String> sameAs;
 
 	private Map<String, List<String>> tmpIsPartOf;
 	private Map<String, List<String>> tmpHasPart;
@@ -110,14 +109,16 @@ public class Place extends Entity {
 		this.altitude = altitude;
 	}
 
-	
-	public List<String> getExactMatch() {
-		return exactMatch;
+	@Override
+	@JsonSetter(SAME_AS)
+	public void setSameReferenceLinks(List<String> uris) {
+		this.sameAs = uris;
 	}
 
-	
-	public void setExactMatch(List<String> exactMatch) {
-		this.exactMatch = exactMatch;
+	@Override
+	@JsonGetter(SAME_AS)
+	public List<String> getSameReferenceLinks() {
+		return this.sameAs;
 	}
 
 

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/Timespan.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/Timespan.java
@@ -49,6 +49,7 @@ public class Timespan extends Entity {
     private List<String> isNextInSequence;
     private String begin;
     private String end;
+    private List<String> sameAs;
 
     @JsonGetter(IS_NEXT_IN_SEQUENCE)
     @JacksonXmlProperty(localName = XmlFields.XML_EDM_IS_NEXT_IN_SEQUENCE)
@@ -158,4 +159,15 @@ public class Timespan extends Entity {
         field.set(this, value);
     }
 
+    @Override
+    @JsonSetter(SAME_AS)
+    public void setSameReferenceLinks(List<String> uris) {
+        this.sameAs = uris;
+    }
+
+    @Override
+    @JsonGetter(SAME_AS)
+    public List<String> getSameReferenceLinks() {
+        return this.sameAs;
+    }
 }

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/utils/SchemaOrgUtils.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/utils/SchemaOrgUtils.java
@@ -88,7 +88,7 @@ public final class SchemaOrgUtils {
         addMultilingualProperties(conceptObject, concept.getNote(), SchemaOrgConstants.PROPERTY_DESCRIPTION);
 
         // sameAs
-        addTextProperties(conceptObject, concept.getExactMatch(), SchemaOrgConstants.PROPERTY_SAME_AS);
+        addTextProperties(conceptObject, concept.getSameReferenceLinks(), SchemaOrgConstants.PROPERTY_SAME_AS);
 
         // url
         addEntityPageUrl(concept, conceptObject, SchemaOrgConstants.ENTITY_PAGE_URL_CONCEPT_TYPE);
@@ -141,7 +141,7 @@ public final class SchemaOrgUtils {
         addReferences(placeObject, edmPlace.getIsPartOfArray(), SchemaOrgConstants.PROPERTY_CONTAINED_IN_PLACE, eu.europeana.corelib.edm.model.schemaorg.Place.class, null);
 
         // sameAs
-        addTextProperties(placeObject, edmPlace.getOwlSameAs(), SchemaOrgConstants.PROPERTY_SAME_AS);
+        addTextProperties(placeObject, edmPlace.getSameReferenceLinks(), SchemaOrgConstants.PROPERTY_SAME_AS);
 
         // url
         //not available yet
@@ -255,7 +255,7 @@ public final class SchemaOrgUtils {
         }
 
         // sameAs
-        addTextProperties(agentObject, agent.getOwlSameAs(), SchemaOrgConstants.PROPERTY_SAME_AS);
+        addTextProperties(agentObject, agent.getSameReferenceLinks(), SchemaOrgConstants.PROPERTY_SAME_AS);
 
         // url
         addEntityPageUrl(agent, agentObject, SchemaOrgConstants.ENTITY_PAGE_URL_AGENT_TYPE);
@@ -302,7 +302,7 @@ public final class SchemaOrgUtils {
         addTextProperties(entityObject, organization.getIdentifier(), SchemaOrgConstants.PROPERTY_IDENTIFIER);
 
         // sameAs
-        addTextProperties(entityObject, organization.getOwlSameAs(), SchemaOrgConstants.PROPERTY_SAME_AS);
+        addTextProperties(entityObject, organization.getSameReferenceLinks(), SchemaOrgConstants.PROPERTY_SAME_AS);
 
         // url
         addEntityPageUrl(organization, entityObject, SchemaOrgConstants.ENTITY_PAGE_URL_ORGANIZATION_TYPE);
@@ -336,7 +336,7 @@ public final class SchemaOrgUtils {
         addEntityPageUrl(time, timespanObject, SchemaOrgConstants.ENTITY_PAGE_URL_TIMESPAN_TYPE);
 
         // sameAs
-        addTextProperties(timespanObject, time.getOwlSameAs(), SchemaOrgConstants.PROPERTY_SAME_AS);
+        addTextProperties(timespanObject, time.getSameReferenceLinks(), SchemaOrgConstants.PROPERTY_SAME_AS);
 
     }
 

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/web/xml/model/XmlAgentImpl.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/web/xml/model/XmlAgentImpl.java
@@ -17,6 +17,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 public class XmlAgentImpl extends XmlBaseEntityImpl<Agent> {
 
+  @XmlElement(namespace = XmlConstants.NAMESPACE_OWL, name = XmlConstants.XML_SAME_AS)
+  private List<LabelledResource> sameAs = new ArrayList<>();
+
   @XmlElement(name = XML_IS_PART_OF, namespace = NAMESPACE_DC_TERMS)
   private List<LabelledResource> isPartOf = new ArrayList<>();
 
@@ -222,6 +225,15 @@ public class XmlAgentImpl extends XmlBaseEntityImpl<Agent> {
     return EntityTypes.Agent;
   }
 
+  @Override
+  public List<LabelledResource> getSameReferenceLinks() {
+    return this.sameAs;
+  }
+
+  @Override
+  public void setSameReferenceLinks(List<LabelledResource> uris) {
+    this.sameAs = uris;
+  }
 
   private<T> T getFirstValue(List<T> list){
      if(list == null) {

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/web/xml/model/XmlBaseEntityImpl.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/web/xml/model/XmlBaseEntityImpl.java
@@ -33,9 +33,6 @@ public abstract class XmlBaseEntityImpl<T extends Entity> {
     @XmlElement(namespace = XmlConstants.NAMESPACE_SKOS, name = PREF_LABEL)
     private List<LabelledResource> prefLabel = new ArrayList<>();
 
-  @XmlElement(namespace = XmlConstants.NAMESPACE_OWL, name = XmlConstants.XML_SAME_AS)
-  private List<LabelledResource> sameAs = new ArrayList<>();
-
 
     @XmlElement(namespace = XmlConstants.NAMESPACE_ORE, name = XmlConstants.IS_AGGREGATED_BY)
     private XmlAggregationImpl isAggregatedBy;
@@ -53,7 +50,7 @@ public abstract class XmlBaseEntityImpl<T extends Entity> {
 	this.about = entity.getAbout();
 	this.prefLabel = RdfXmlUtils.convertMapToXmlMultilingualString(entity.getPrefLabel());
 	this.altLabel = RdfXmlUtils.convertToXmlMultilingualString(entity.getAltLabel());
-	this.sameAs = RdfXmlUtils.convertToRdfResource(entity.getSameAs());
+	setSameReferenceLinks(RdfXmlUtils.convertToRdfResource(entity.getSameReferenceLinks()));
 	// isAggregatedBy not always set in tests
     // TODO: fix tests, then remove null check here
     if(entity.getIsAggregatedBy() != null) {
@@ -79,7 +76,8 @@ public abstract class XmlBaseEntityImpl<T extends Entity> {
 	entity.setEntityId(getAbout());
 	entity.setPrefLabel(RdfXmlUtils.toLanguageMap(getPrefLabel()));
 	entity.setAltLabel(RdfXmlUtils.toLanguageMapList(getAltLabel()));
-	entity.setSameAs(RdfXmlUtils.toStringList(getSameAs()));
+	// sets sameAs or exactMatch values (for concepts)
+	entity.setSameReferenceLinks(RdfXmlUtils.toStringList(getSameReferenceLinks()));
 	if(depiction != null) {
 	    entity.setDepiction(XmlWebResourceImpl.toWebResource(depiction));
 	}
@@ -110,12 +108,10 @@ public abstract class XmlBaseEntityImpl<T extends Entity> {
 	return this.altLabel;
     }
 
-    public List<LabelledResource> getSameAs() {
-	return this.sameAs;
-    }
-
     public T getEntity() {
 	return entity;
     }
 
+    public abstract List<LabelledResource> getSameReferenceLinks();
+    public abstract void setSameReferenceLinks(List<LabelledResource> uris);
 }

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/web/xml/model/XmlConceptImpl.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/web/xml/model/XmlConceptImpl.java
@@ -66,7 +66,6 @@ public class XmlConceptImpl extends XmlBaseEntityImpl<Concept> {
         this.broader = RdfXmlUtils.convertToRdfResource(concept.getBroader());
         this.broadMatch = RdfXmlUtils.convertToRdfResource(concept.getBroadMatch());
         this.narrowMatch = RdfXmlUtils.convertToRdfResource(concept.getNarrowMatch());
-        this.exactMatch = RdfXmlUtils.convertToRdfResource(concept.getExactMatch());
         this.relatedMatch = RdfXmlUtils.convertToRdfResource(concept.getRelatedMatch());
         this.closeMatch = RdfXmlUtils.convertToRdfResource(concept.getCloseMatch());
         this.note = RdfXmlUtils.convertToXmlMultilingualString(concept.getNote());
@@ -83,7 +82,6 @@ public class XmlConceptImpl extends XmlBaseEntityImpl<Concept> {
         entity.setBroader(RdfXmlUtils.toStringList(getBroader()));
         entity.setBroadMatch(RdfXmlUtils.toStringList(getBroadMatch()));
         entity.setNarrowMatch(RdfXmlUtils.toStringList(getNarrowMatch()));
-        entity.setExactMatch(RdfXmlUtils.toStringList(getExactMatch()));
         entity.setRelatedMatch(RdfXmlUtils.toStringList(getRelatedMatch()));
         entity.setCloseMatch(RdfXmlUtils.toStringList(getCloseMatch()));
         entity.setInScheme(RdfXmlUtils.toStringList(getInScheme()));
@@ -152,5 +150,15 @@ public class XmlConceptImpl extends XmlBaseEntityImpl<Concept> {
     @Override
     protected EntityTypes getTypeEnum() {
 	return  EntityTypes.Concept;
+    }
+
+    @Override
+    public List<LabelledResource> getSameReferenceLinks() {
+        return this.exactMatch;
+    }
+
+    @Override
+    public void setSameReferenceLinks(List<LabelledResource> uris) {
+        this.exactMatch = uris;
     }
 }

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/web/xml/model/XmlOrganizationImpl.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/web/xml/model/XmlOrganizationImpl.java
@@ -34,6 +34,9 @@ import eu.europeana.entitymanagement.vocabulary.EntityTypes;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class XmlOrganizationImpl extends XmlBaseEntityImpl<Organization> {
 
+	@XmlElement(namespace = XmlConstants.NAMESPACE_OWL, name = XmlConstants.XML_SAME_AS)
+	private List<LabelledResource> sameAs = new ArrayList<>();
+
 	@XmlElement(namespace = NAMESPACE_EDM, name = XML_ACRONYM)
 	private List<LabelledResource> acronym = new ArrayList<>();
 
@@ -165,5 +168,15 @@ public class XmlOrganizationImpl extends XmlBaseEntityImpl<Organization> {
 	@Override
 	protected EntityTypes getTypeEnum() {
 	    return EntityTypes.Organization;
+	}
+
+	@Override
+	public List<LabelledResource> getSameReferenceLinks() {
+		return this.sameAs;
+	}
+
+	@Override
+	public void setSameReferenceLinks(List<LabelledResource> uris) {
+		this.sameAs = uris;
 	}
 }

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/web/xml/model/XmlPlaceImpl.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/web/xml/model/XmlPlaceImpl.java
@@ -16,6 +16,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class XmlPlaceImpl extends XmlBaseEntityImpl<Place> {
 
+	@XmlElement(namespace = XmlConstants.NAMESPACE_OWL, name = XmlConstants.XML_SAME_AS)
+	private List<LabelledResource> sameAs = new ArrayList<>();
+
 		@XmlElement(namespace = NAMESPACE_WGS84_POS, name = XML_WGS84_POS_LAT)
 		private Float latitude;
 
@@ -107,5 +110,15 @@ public class XmlPlaceImpl extends XmlBaseEntityImpl<Place> {
 	@Override
 	protected EntityTypes getTypeEnum() {
 	    return EntityTypes.Place;
+	}
+
+	@Override
+	public List<LabelledResource> getSameReferenceLinks() {
+		return this.sameAs;
+	}
+
+	@Override
+	public void setSameReferenceLinks(List<LabelledResource> uris) {
+		this.sameAs = uris;
 	}
 }

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/web/xml/model/XmlTimespanImpl.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/web/xml/model/XmlTimespanImpl.java
@@ -16,6 +16,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class XmlTimespanImpl extends XmlBaseEntityImpl<Timespan> {
 
+  @XmlElement(namespace = XmlConstants.NAMESPACE_OWL, name = XmlConstants.XML_SAME_AS)
+  private List<LabelledResource> sameAs = new ArrayList<>();
+
   @XmlElement(namespace = NAMESPACE_SKOS, name =  HIDDEN_LABEL)
   private List<LabelledResource> hiddenLabel = new ArrayList<>();
 
@@ -98,4 +101,14 @@ public class XmlTimespanImpl extends XmlBaseEntityImpl<Timespan> {
 	protected EntityTypes getTypeEnum() {
 	    return EntityTypes.Timespan;
 	}
+
+  @Override
+  public List<LabelledResource> getSameReferenceLinks() {
+    return this.sameAs;
+  }
+
+  @Override
+  public void setSameReferenceLinks(List<LabelledResource> uris) {
+    this.sameAs = uris;
+  }
 }

--- a/entity-management-enrichment/src/main/java/eu/europeana/entitymanagement/service/EnrichmentService.java
+++ b/entity-management-enrichment/src/main/java/eu/europeana/entitymanagement/service/EnrichmentService.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 
 @Service
 public class EnrichmentService {
@@ -47,8 +48,8 @@ public class EnrichmentService {
             enrichmentEntity.setAltLabel(entityRecord.getEntity().getAltLabel());
             enrichmentEntity.setHiddenLabel(entityRecord.getEntity().getHiddenLabel());
             enrichmentEntity.setNote(entityRecord.getEntity().getNote());
-            if(entityRecord.getEntity().getSameAs() != null && !entityRecord.getEntity().getSameAs().isEmpty()) {
-                enrichmentEntity.setOwlSameAs(entityRecord.getEntity().getSameAs());
+            if(!CollectionUtils.isEmpty(entityRecord.getEntity().getSameReferenceLinks())) {
+                enrichmentEntity.setOwlSameAs(entityRecord.getEntity().getSameReferenceLinks());
             }
             enrichmentEntity.setIsPartOf(String.valueOf(entityRecord.getEntity().getIsPartOfArray()));
             enrichmentEntity.setFoafDepiction(entityRecord.getEntity().getDepiction() != null ?

--- a/entity-management-mongo/src/main/java/eu/europeana/entitymanagement/mongo/repository/EntityRecordRepository.java
+++ b/entity-management-mongo/src/main/java/eu/europeana/entitymanagement/mongo/repository/EntityRecordRepository.java
@@ -155,16 +155,16 @@ public class EntityRecordRepository {
 
 
     /**
-     * Gets EntityRecord containing the given id in its sameAs or exactMatch fields.
-     * @param id id to query
+     * Gets EntityRecord containing the given uris in its sameAs or exactMatch fields.
+     * @param uris uris to query
      * @return Optional containing result, or empty Optional if no match
      */
-    public Optional<EntityRecord> findMatchingEntitiesByCoreference(String id) {
+    public Optional<EntityRecord> findMatchingEntitiesByCoreference(List<String> uris) {
 
         EntityRecord value = datastore.find(EntityRecord.class).disableValidation()
                 .filter(or(
-                        eq(ENTITY_SAME_AS, id),
-                        eq(ENTITY_EXACT_MATCH, id)
+                        in(ENTITY_SAME_AS, uris),
+                        in(ENTITY_EXACT_MATCH, uris)
                         )
                 ).first();
 

--- a/entity-management-solr/src/main/java/eu/europeana/entitymanagement/solr/model/SolrAgent.java
+++ b/entity-management-solr/src/main/java/eu/europeana/entitymanagement/solr/model/SolrAgent.java
@@ -22,6 +22,9 @@ public class SolrAgent extends SolrEntity<Agent> {
 		super();
 	}
 
+	@Field(EntitySolrFields.SAME_AS)
+	private List<String> sameAs;
+
 	@Field(AgentSolrFields.DATE)
 	private List<String> date;
 
@@ -180,5 +183,10 @@ public class SolrAgent extends SolrEntity<Agent> {
 
 	public String getGender() {
 		return gender;
+	}
+
+	@Override
+	protected void setSameReferenceLinks(ArrayList<String> uris) {
+		this.sameAs = uris;
 	}
 }

--- a/entity-management-solr/src/main/java/eu/europeana/entitymanagement/solr/model/SolrConcept.java
+++ b/entity-management-solr/src/main/java/eu/europeana/entitymanagement/solr/model/SolrConcept.java
@@ -60,7 +60,6 @@ public class SolrConcept extends SolrEntity<Concept> {
 		if(concept.getRelated()!=null) this.related= new ArrayList<>(concept.getRelated());
 		if(concept.getBroadMatch()!=null) this.broadMatch=new ArrayList<>(concept.getBroadMatch());
 		if(concept.getNarrowMatch()!=null) this.narrowMatch= new ArrayList<>(concept.getNarrowMatch());
-		if(concept.getExactMatch()!=null) this.exactMatch= new ArrayList<>(concept.getExactMatch());
 		if(concept.getCoref()!=null) this.coref=new ArrayList<>(concept.getCoref());
 		if(concept.getRelatedMatch()!=null) this.relatedMatch= new ArrayList<>(concept.getRelatedMatch());
 		if(concept.getCloseMatch()!=null) this.closeMatch= new ArrayList<>(concept.getCloseMatch());
@@ -116,5 +115,10 @@ public class SolrConcept extends SolrEntity<Concept> {
 
 	public Map<String, List<String>> getNotation() {
 		return notation;
+	}
+
+	@Override
+	protected void setSameReferenceLinks(ArrayList<String> uris) {
+		this.exactMatch = exactMatch;
 	}
 }

--- a/entity-management-solr/src/main/java/eu/europeana/entitymanagement/solr/model/SolrEntity.java
+++ b/entity-management-solr/src/main/java/eu/europeana/entitymanagement/solr/model/SolrEntity.java
@@ -41,9 +41,6 @@ public abstract class SolrEntity<T extends Entity> {
     @Field(EntitySolrFields.IDENTIFIER)
     private List<String> identifier;
 
-    @Field(EntitySolrFields.SAME_AS)
-    private List<String> sameAs;
-
     @Field(EntitySolrFields.IS_RELATED_TO)
     private List<String> isRelatedTo;
 
@@ -71,14 +68,13 @@ public abstract class SolrEntity<T extends Entity> {
         setHiddenLabel(entity.getHiddenLabel());
         setIsShownBy(entity.getIsShownBy());
         if(entity.getIdentifier()!=null) this.identifier = new ArrayList<>(entity.getIdentifier());
-        if(entity.getSameAs()!=null) this.sameAs = new ArrayList<>(entity.getSameAs());
+        if(entity.getSameReferenceLinks() != null) this.setSameReferenceLinks(new ArrayList<>(entity.getSameReferenceLinks()));
         if(entity.getIsRelatedTo()!=null) this.isRelatedTo = new ArrayList<>(entity.getIsRelatedTo());
         if(entity.getHasPart()!=null) this.hasPart = new ArrayList<>(entity.getHasPart());
         if(entity.getIsPartOfArray()!=null) this.isPartOf = new ArrayList<>(entity.getIsPartOfArray());
 
         this.entity = entity;
     }
-
 
     public SolrEntity() {
     // no-arg constructor
@@ -159,10 +155,6 @@ public abstract class SolrEntity<T extends Entity> {
         return identifier;
     }
 
-    public List<String> getSameAs() {
-        return sameAs;
-    }
-
     public List<String> getIsRelatedTo() {
         return isRelatedTo;
     }
@@ -182,4 +174,6 @@ public abstract class SolrEntity<T extends Entity> {
     public T getEntity() {
         return entity;
     }
+
+    protected abstract void setSameReferenceLinks(ArrayList<String> uris);
 }

--- a/entity-management-solr/src/main/java/eu/europeana/entitymanagement/solr/model/SolrOrganization.java
+++ b/entity-management-solr/src/main/java/eu/europeana/entitymanagement/solr/model/SolrOrganization.java
@@ -18,6 +18,9 @@ import static eu.europeana.entitymanagement.solr.SolrUtils.SOLR_ORGANIZATION_SUG
 
 public class SolrOrganization extends SolrEntity<Organization> {
 
+	@Field(EntitySolrFields.SAME_AS)
+	private List<String> sameAs;
+
 	@Field(OrganizationSolrFields.DC_DESCRIPTION_ALL)
 	private Map<String, String> description;
 	
@@ -207,4 +210,8 @@ public class SolrOrganization extends SolrEntity<Organization> {
 		return hasGeo;
 	}
 
+	@Override
+	protected void setSameReferenceLinks(ArrayList<String> uris) {
+		this.sameAs = uris;
+	}
 }

--- a/entity-management-solr/src/main/java/eu/europeana/entitymanagement/solr/model/SolrPlace.java
+++ b/entity-management-solr/src/main/java/eu/europeana/entitymanagement/solr/model/SolrPlace.java
@@ -1,5 +1,6 @@
 package eu.europeana.entitymanagement.solr.model;
 
+import eu.europeana.entitymanagement.vocabulary.EntitySolrFields;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,6 +14,9 @@ import eu.europeana.entitymanagement.vocabulary.PlaceSolrFields;
  */
 public class SolrPlace extends SolrEntity<Place> {
 
+	@Field(EntitySolrFields.SAME_AS)
+	private List<String> sameAs;
+
 	@Field(PlaceSolrFields.IS_NEXT_IN_SEQUENCE)
 	private List<String> isNextInSequence;
 	
@@ -24,9 +28,6 @@ public class SolrPlace extends SolrEntity<Place> {
 	
 	@Field(PlaceSolrFields.ALTITUDE)
 	private Float altitude;
-	
-	@Field(PlaceSolrFields.EXACT_MATCH)
-	private List<String> exactMatch;
 
 	public SolrPlace() {
 		super();
@@ -39,7 +40,6 @@ public class SolrPlace extends SolrEntity<Place> {
 		this.latitude=place.getLatitude();
 		this.longitude=place.getLongitude();
 		this.altitude=place.getAltitude();
-		this.exactMatch=place.getExactMatch();
 	}
 
 	public List<String> getIsNextInSequence() {
@@ -58,9 +58,9 @@ public class SolrPlace extends SolrEntity<Place> {
 		return altitude;
 	}
 
-	public List<String> getExactMatch() {
-		return exactMatch;
+	@Override
+	protected void setSameReferenceLinks(ArrayList<String> uris) {
+		this.sameAs = uris;
 	}
-	
 
 }

--- a/entity-management-solr/src/main/java/eu/europeana/entitymanagement/solr/model/SolrTimespan.java
+++ b/entity-management-solr/src/main/java/eu/europeana/entitymanagement/solr/model/SolrTimespan.java
@@ -1,5 +1,7 @@
 package eu.europeana.entitymanagement.solr.model;
 
+import eu.europeana.entitymanagement.vocabulary.EntitySolrFields;
+import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
@@ -12,7 +14,10 @@ import static eu.europeana.entitymanagement.solr.SolrUtils.SOLR_TIMESPAN_SUGGEST
 
 @JsonFilter(SOLR_TIMESPAN_SUGGESTER_FILTER)
 public class SolrTimespan extends SolrEntity<Timespan> {
-	
+
+	@Field(EntitySolrFields.SAME_AS)
+	private List<String> sameAs;
+
 	@Field(TimespanSolrFields.IS_NEXT_IN_SEQUENCE)
     private List<String> isNextInSequence;
 	
@@ -44,5 +49,10 @@ public class SolrTimespan extends SolrEntity<Timespan> {
 
 	public String getEnd() {
 		return end;
+	}
+
+	@Override
+	protected void setSameReferenceLinks(ArrayList<String> uris) {
+		this.sameAs = uris;
 	}
 }

--- a/entity-management-web/src/integration-test/java/eu/europeana/entitymanagement/web/EntityRecordServiceIT.java
+++ b/entity-management-web/src/integration-test/java/eu/europeana/entitymanagement/web/EntityRecordServiceIT.java
@@ -72,7 +72,7 @@ public class EntityRecordServiceIT extends AbstractIntegrationTest{
          * corresponsing proxy's entity objects
          */
         Assertions.assertNotNull(mergedEntity.getNote());
-        Assertions.assertNotNull(mergedEntity.getSameAs());
+        Assertions.assertNotNull(mergedEntity.getSameReferenceLinks());
         Assertions.assertTrue(mergedEntity.getBroader().size() > 1);
         Assertions.assertNotNull(mergedEntity.getPrefLabel());
     }

--- a/entity-management-web/src/integration-test/java/eu/europeana/entitymanagement/web/EntityRetrievalIT.java
+++ b/entity-management-web/src/integration-test/java/eu/europeana/entitymanagement/web/EntityRetrievalIT.java
@@ -148,7 +148,7 @@ public class EntityRetrievalIT extends BaseWebControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.@id", is(entityRecord.getEntityId())));
 
-        for (String sameAsElem : entityRecord.getEntity().getSameAs()) {
+        for (String sameAsElem : entityRecord.getEntity().getSameReferenceLinks()) {
         	resultActions.andExpect(jsonPath("$.sameAs", Matchers.hasItem(sameAsElem)));
         }
         resultActions.andExpect(jsonPath("$.gender").isNotEmpty());

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/EMController.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/EMController.java
@@ -323,7 +323,7 @@ public class EMController extends BaseRest {
 	
 			// check if id is already being used, if so return a 301
 			Optional<EntityRecord> existingEntity = entityRecordService
-					.findMatchingCoreference(creationRequestId);
+					.findMatchingCoreference(Collections.singletonList(creationRequestId));
 			ResponseEntity<String> response = checkExistingEntity(existingEntity,
 					creationRequestId);
 
@@ -363,7 +363,7 @@ public class EMController extends BaseRest {
 
 			if (datasourceResponse.getSameReferenceLinks() != null) {
 				existingEntity = entityRecordService
-						.retrieveCoreferencedEntity(datasourceResponse.getSameReferenceLinks());
+						.findMatchingCoreference(datasourceResponse.getSameReferenceLinks());
 				response = checkExistingEntity(existingEntity, creationRequestId);
 				if (response != null) {
 					return response;

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/EMController.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/EMController.java
@@ -28,7 +28,6 @@ import eu.europeana.entitymanagement.vocabulary.WebEntityConstants;
 import eu.europeana.entitymanagement.web.model.EntityPreview;
 import eu.europeana.entitymanagement.web.service.DereferenceServiceLocator;
 import eu.europeana.entitymanagement.web.service.EntityRecordService;
-import eu.europeana.entitymanagement.web.service.MetisDereferenceService;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -66,7 +65,7 @@ public class EMController extends BaseRest {
 	private final EntityManagementConfiguration emConfig;
 
 	private static final String EXTERNAL_ID_REMOVED_MSG = "Entity id '%s' already exists as '%s', which has been removed";
-	private static final String SAME_AS_NOT_EXISTS_MSG = "Url '%s' does not exist in entity owl:sameAs";
+	private static final String SAME_AS_NOT_EXISTS_MSG = "Url '%s' does not exist in entity owl:sameAs or skos:exactMatch";
 	public static final String INVALID_UPDATE_REQUEST_MSG = "Request must either specify a 'query' param or contain entity identifiers in body";
 
 
@@ -362,9 +361,9 @@ public class EMController extends BaseRest {
 						datasourceResponse.getType(), creationRequestType));
 			}
 
-			if (datasourceResponse.getSameAs() != null) {
+			if (datasourceResponse.getSameReferenceLinks() != null) {
 				existingEntity = entityRecordService
-						.retrieveCoreferenceSameAs(datasourceResponse.getSameAs());
+						.retrieveCoreferencedEntity(datasourceResponse.getSameReferenceLinks());
 				response = checkExistingEntity(existingEntity, creationRequestId);
 				if (response != null) {
 					return response;
@@ -399,7 +398,7 @@ public class EMController extends BaseRest {
 		}
 		EntityRecord entityRecord = entityRecordService.retrieveEntityRecord(type, identifier, false);
 
-		if(!entityRecord.getEntity().getSameAs().contains(url)){
+		if(!entityRecord.getEntity().getSameReferenceLinks().contains(url)){
 			throw new HttpBadRequestException(String.format(SAME_AS_NOT_EXISTS_MSG, url));
 		}
 

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/service/EntityRecordService.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/service/EntityRecordService.java
@@ -174,7 +174,7 @@ public class EntityRecordService {
 		 * sameAs will be replaced during consolidation; however we set this here to prevent duplicate
 		 * registrations if consolidation fails
 		 */
-		entity.setSameAs(Collections.singletonList(entityCreationRequest.getId()));
+		entity.setSameReferenceLinks(Collections.singletonList(entityCreationRequest.getId()));
 		entityRecord.setEntity(entity);
 
 		Entity europeanaProxyMetadata = EntityObjectFactory.createEntityObject(type);
@@ -229,7 +229,7 @@ public class EntityRecordService {
 		 * sameAs will be replaced during consolidation; however we set this here to prevent duplicate
 		 * registrations if consolidation fails
 		 */
-		entity.setSameAs(Collections.singletonList(entityCreationRequest.getId()));
+		entity.setSameReferenceLinks(Collections.singletonList(entityCreationRequest.getId()));
 		entityRecord.setEntity(entity);
 
 
@@ -293,22 +293,22 @@ public class EntityRecordService {
     }
 
     /**
-     * Checks if any of the resources in the SameAs field from the Datasource is already
+     * Checks if any of the resources in the SameAs / ExactMatch field from the Datasource is already
      * known.
      * 
-     * @param rdfResources list of SameAs resources
+     * @param rdfResources list of SameAs/ExactMatch resources
      * @return Optional containing EntityRecord, or empty Optional if none found
      */
-    public Optional<EntityRecord> retrieveCoreferenceSameAs(List<String> rdfResources) {
-	for (String resource : rdfResources) {
-	    Optional<EntityRecord> entityRecordOptional = retrieveByEntityId(resource);
-	    if (entityRecordOptional.isPresent()) {
-		return entityRecordOptional;
-	    }
-	}
+		public Optional<EntityRecord> retrieveCoreferencedEntity(List<String> rdfResources) {
+			for (String resource : rdfResources) {
+				Optional<EntityRecord> entityRecordOptional = retrieveByEntityId(resource);
+				if (entityRecordOptional.isPresent()) {
+					return entityRecordOptional;
+				}
+			}
 
-	return Optional.empty();
-    }
+			return Optional.empty();
+		}
 
     public void performReferentialIntegrity(Entity entity)  {
 
@@ -636,15 +636,15 @@ public class EntityRecordService {
 
 		}
 
-		// Add external proxy id to consolidated entity sameAs
+		// Add external proxy id to consolidated entity sameAs / exactMatch
 		String externalProxyId = secondary.getEntityId();
-		List<String> consolidatedEntitySameAs = consolidatedEntity.getSameAs();
+		List<String> consolidatedEntitySameRefs = consolidatedEntity.getSameReferenceLinks();
 
-		if (consolidatedEntitySameAs == null) {
-			consolidatedEntity.setSameAs(Collections.singletonList(externalProxyId));
+		if (consolidatedEntitySameRefs == null) {
+			consolidatedEntity.setSameReferenceLinks(Collections.singletonList(externalProxyId));
 		}
-		else if (!consolidatedEntitySameAs.contains(externalProxyId)) {
-			consolidatedEntitySameAs.add(externalProxyId);
+		else if (!consolidatedEntitySameRefs.contains(externalProxyId)) {
+			consolidatedEntitySameRefs.add(externalProxyId);
 		}
 
 		return consolidatedEntity;

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/service/EntityRecordService.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/service/EntityRecordService.java
@@ -88,11 +88,11 @@ public class EntityRecordService {
      * Gets coreferenced entity with the given id (sameAs or exactMatch value in the
      * Consolidated version)
      * 
-     * @param id co-reference id
+     * @param uris co-reference uris
      * @return Optional containing matching record, or empty optional if none found.
      */
-    public Optional<EntityRecord> findMatchingCoreference(String id) {
-	return entityRecordRepository.findMatchingEntitiesByCoreference(id);
+    public Optional<EntityRecord> findMatchingCoreference(List<String> uris) {
+	return entityRecordRepository.findMatchingEntitiesByCoreference(uris);
     }
 
     public EntityRecord saveEntityRecord(EntityRecord er) {
@@ -292,24 +292,6 @@ public class EntityRecordService {
 	}
     }
 
-    /**
-     * Checks if any of the resources in the SameAs / ExactMatch field from the Datasource is already
-     * known.
-     * 
-     * @param rdfResources list of SameAs/ExactMatch resources
-     * @return Optional containing EntityRecord, or empty Optional if none found
-     */
-		public Optional<EntityRecord> retrieveCoreferencedEntity(List<String> rdfResources) {
-			for (String resource : rdfResources) {
-				Optional<EntityRecord> entityRecordOptional = retrieveByEntityId(resource);
-				if (entityRecordOptional.isPresent()) {
-					return entityRecordOptional;
-				}
-			}
-
-			return Optional.empty();
-		}
-
     public void performReferentialIntegrity(Entity entity)  {
 
 	//TODO: consider refactoring the implementation of this method by creating a new class (e.g. ReferentialIntegrityProcessor) 
@@ -453,7 +435,7 @@ public class EntityRecordService {
 	    updatedReferences.add(value);
 	} else {
 	    //value is external URI, replace it with internal reference if they are accessible
-	    Optional<EntityRecord> record = findMatchingCoreference(value);
+	    Optional<EntityRecord> record = findMatchingCoreference(Collections.singletonList(value));
 		record.ifPresent(entityRecord -> updatedReferences.add(entityRecord.getEntityId()));
 	}
     }

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/service/ScoringService.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/web/service/ScoringService.java
@@ -250,10 +250,10 @@ public class ScoringService {
     }
 
     private String getWikidataUrl(Entity entity) {
-	if (entity.getSameAs() == null) {
+	if (entity.getSameReferenceLinks() == null) {
 	    return null;
 	}
-	List<String> values = entity.getSameAs();
+	List<String> values = entity.getSameReferenceLinks();
 
 	String wikidataUri = values.stream().filter(value -> value.startsWith(WIKIDATA_PREFFIX)).findFirst()
 		.orElse(null);

--- a/entity-management-web/src/test/java/eu/europeana/entitymanagement/web/service/impl/ScoringServiceTest.java
+++ b/entity-management-web/src/test/java/eu/europeana/entitymanagement/web/service/impl/ScoringServiceTest.java
@@ -46,7 +46,7 @@ public class ScoringServiceTest {
 	agent.setEntityId(entityId);
 	List<String> sameAs = List.of("http://wikidata.dbpedia.org/resource/Q762",
 		"http://www.wikidata.org/entity/Q762", "http://purl.org/collections/nl/am/p-10456" );
-	agent.setSameAs(sameAs);
+	agent.setSameReferenceLinks(sameAs);
 
 	Map<String, String> prefLabels = new HashMap<String, String>();
 	prefLabels.put("en", "Leonardo da Vinci");
@@ -78,7 +78,7 @@ public class ScoringServiceTest {
         String entityId = "http://data.europeana.eu/place/base/41488";
         agent.setEntityId(entityId);
         List<String> sameAs = List.of("https://sws.geonames.org/2988507/");
-        agent.setSameAs(sameAs);
+        agent.setSameReferenceLinks(sameAs);
         
         Map<String, String> prefLabels = new HashMap<String, String>();
         prefLabels.put("en", "Paris");

--- a/entity-management-web/src/test/resources/consolidated/concept-consolidated-bathtub.json
+++ b/entity-management-web/src/test/resources/consolidated/concept-consolidated-bathtub.json
@@ -68,6 +68,6 @@
 	  "id":"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e8/1rm60rt0t_rtbcwh.jpg/330px-1rm60rt0t_rtbcwh.jpg",
 	  "source": "http://valid-uri-for-testing"
   },
-  "sameAs": [ "http://www.wikidata.org/entity/Q152095"],
+  "exactMatch": [ "http://www.wikidata.org/entity/Q152095"],
   "broader":["http://www.wikidata.org/entity/Q987767"]
 }

--- a/entity-management-web/src/test/resources/content/concept_register_bathtub.json
+++ b/entity-management-web/src/test/resources/content/concept_register_bathtub.json
@@ -12,7 +12,7 @@
     "de": [ "badefass-europeana", "Oder Badewanne - europeana", "Nocheine Badewanne - europeana"],
     "ro": [ "Cada de facut baie - europeana", "Inca o cada de baie" ]
   },
-  "sameAs": [ "http://www.wikidata.org/entity/Q152095"],
+  "exactMatch": [ "http://www.wikidata.org/entity/Q152095"],
   "depiction": {
     "id": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e8/1rm60rt0t_rtbcwh.jpg/330px-1rm60rt0t_rtbcwh.jpg",
     "source": "http://valid-uri-for-testing"

--- a/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/wikidata/WikidataAccessService.java
+++ b/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/wikidata/WikidataAccessService.java
@@ -120,16 +120,14 @@ public class WikidataAccessService implements Dereferencer {
 	    List<String> mbox = ZohoUtils.mergeStringLists(organization.getMbox(), wikidataOrganizationEntity.getMbox());
 	    organization.setMbox(mbox);
 	    List<String> sameAs = this.buildSameAs(organization, wikidataOrganizationEntity);
-	    organization.setSameAs(sameAs);
+	    organization.setSameReferenceLinks(sameAs);
 	    organization.setDescription(wikidataOrganizationEntity.getDescription());
 	    mergeAddress(organization, wikidataOrganizationEntity);
     }
 
 	private List<String> buildSameAs(Organization organization, Organization wikidataOrganization) {
-	    List<String> mergedSameAs = organization.getOwlSameAs();
-	    for (int i = 0; i < wikidataOrganization.getOwlSameAs().size(); i++) {
-	      mergedSameAs.add(wikidataOrganization.getOwlSameAs().get(i));
-	    }
+	    List<String> mergedSameAs = organization.getSameReferenceLinks();
+			mergedSameAs.addAll(wikidataOrganization.getSameReferenceLinks());
 	    String wikidataResourceUri = wikidataOrganization.getAbout();
 	    if (!mergedSameAs.contains(wikidataResourceUri)) {
 	        mergedSameAs.add(wikidataResourceUri);

--- a/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/zoho/organization/ZohoOrganizationConverter.java
+++ b/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/zoho/organization/ZohoOrganizationConverter.java
@@ -52,7 +52,7 @@ public class ZohoOrganizationConverter {
         org.setCountry(organizationCountry);
         List<String> sameAs = getAllSameAs(record);
         if (!sameAs.isEmpty()) {
-            org.setSameAs(sameAs);
+            org.setSameReferenceLinks(sameAs);
 
         }
         


### PR DESCRIPTION
Concepts now contain `skos:exactMatch`, while all other entity types use `owl:sameAs`