### PR TITLE
EA-2752: Improve Zoho dereferencing

### DIFF
--- a/entity-management-web/src/test/resources/wikidata-deref/organization_wikidata_bnf_response.xml
+++ b/entity-management-web/src/test/resources/wikidata-deref/organization_wikidata_bnf_response.xml
@@ -36,23 +36,16 @@
     <schema:about rdf:resource="http://www.wikidata.org/entity/Q641676"/>
     <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/"/>
     <schema:softwareVersion>1.0.0</schema:softwareVersion>
-    <schema:version rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1484829065
-    </schema:version>
-    <schema:dateModified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2021-08-21T03:24:28Z
-    </schema:dateModified>
-    <wikibase:statements rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">74
-    </wikibase:statements>
-    <wikibase:sitelinks rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17
-    </wikibase:sitelinks>
-    <wikibase:identifiers rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">34
-    </wikibase:identifiers>
+    <schema:version rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1484829065</schema:version>
+    <schema:dateModified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-21T03:24:28Z</schema:dateModified>
+    <wikibase:statements rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">74</wikibase:statements>
+    <wikibase:sitelinks rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">17</wikibase:sitelinks>
+    <wikibase:identifiers rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">34</wikibase:identifiers>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Item"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="https://la.wikipedia.org/wiki/Museum_Historiae_Naturalis_Lugduno-Batavum">
+  <rdf:Description rdf:about="https://la.wikipedia.org/wiki/Museum_Historiae_Naturalis_Lugduno-Batavum">
     <rdf:type rdf:resource="http://schema.org/Article"/>
     <schema:about rdf:resource="http://www.wikidata.org/entity/Q641676"/>
     <schema:inLanguage>la</schema:inLanguage>
@@ -72,8 +65,7 @@
   <rdf:Description rdf:about="https://de.wikipedia.org/">
     <wikibase:wikiGroup>wikipedia</wikibase:wikiGroup>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="https://ja.wikipedia.org/wiki/%E3%83%8A%E3%83%81%E3%83%A5%E3%83%A9%E3%83%AA%E3%82%B9%E7%94%9F%E7%89%A9%E5%A4%9A%E6%A7%98%E6%80%A7%E3%82%BB%E3%83%B3%E3%82%BF%E3%83%BC">
+  <rdf:Description rdf:about="https://ja.wikipedia.org/wiki/%E3%83%8A%E3%83%81%E3%83%A5%E3%83%A9%E3%83%AA%E3%82%B9%E7%94%9F%E7%89%A9%E5%A4%9A%E6%A7%98%E6%80%A7%E3%82%BB%E3%83%B3%E3%82%BF%E3%83%BC">
     <rdf:type rdf:resource="http://schema.org/Article"/>
     <schema:about rdf:resource="http://www.wikidata.org/entity/Q641676"/>
     <schema:inLanguage>ja</schema:inLanguage>
@@ -93,8 +85,7 @@
   <rdf:Description rdf:about="https://nl.wikipedia.org/">
     <wikibase:wikiGroup>wikipedia</wikibase:wikiGroup>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="https://pt.wikipedia.org/wiki/Museu_de_Hist%C3%B3ria_Natural_de_Leiden">
+  <rdf:Description rdf:about="https://pt.wikipedia.org/wiki/Museu_de_Hist%C3%B3ria_Natural_de_Leiden">
     <rdf:type rdf:resource="http://schema.org/Article"/>
     <schema:about rdf:resource="http://www.wikidata.org/entity/Q641676"/>
     <schema:inLanguage>pt</schema:inLanguage>
@@ -124,8 +115,7 @@
   <rdf:Description rdf:about="https://pl.wikipedia.org/">
     <wikibase:wikiGroup>wikipedia</wikibase:wikiGroup>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="https://uk.wikipedia.org/wiki/%D0%A6%D0%B5%D0%BD%D1%82%D1%80_%D0%B1%D1%96%D0%BE%D1%80%D1%96%D0%B7%D0%BD%D0%BE%D0%BC%D0%B0%D0%BD%D1%96%D1%82%D1%82%D1%8F_%C2%AB%D0%9D%D0%B0%D1%82%D1%83%D1%80%D0%B0%D0%BB%D1%96%D1%81%C2%BB">
+  <rdf:Description rdf:about="https://uk.wikipedia.org/wiki/%D0%A6%D0%B5%D0%BD%D1%82%D1%80_%D0%B1%D1%96%D0%BE%D1%80%D1%96%D0%B7%D0%BD%D0%BE%D0%BC%D0%B0%D0%BD%D1%96%D1%82%D1%82%D1%8F_%C2%AB%D0%9D%D0%B0%D1%82%D1%83%D1%80%D0%B0%D0%BB%D1%96%D1%81%C2%BB">
     <rdf:type rdf:resource="http://schema.org/Article"/>
     <schema:about rdf:resource="http://www.wikidata.org/entity/Q641676"/>
     <schema:inLanguage>uk</schema:inLanguage>
@@ -145,8 +135,7 @@
   <rdf:Description rdf:about="https://en.wikipedia.org/">
     <wikibase:wikiGroup>wikipedia</wikibase:wikiGroup>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="https://zh.wikipedia.org/wiki/%E8%87%AA%E7%84%B6%E7%94%9F%E7%89%A9%E5%A4%9A%E6%A8%A3%E6%80%A7%E4%B8%AD%E5%BF%83">
+  <rdf:Description rdf:about="https://zh.wikipedia.org/wiki/%E8%87%AA%E7%84%B6%E7%94%9F%E7%89%A9%E5%A4%9A%E6%A8%A3%E6%80%A7%E4%B8%AD%E5%BF%83">
     <rdf:type rdf:resource="http://schema.org/Article"/>
     <schema:about rdf:resource="http://www.wikidata.org/entity/Q641676"/>
     <schema:inLanguage>zh</schema:inLanguage>
@@ -156,8 +145,7 @@
   <rdf:Description rdf:about="https://zh.wikipedia.org/">
     <wikibase:wikiGroup>wikipedia</wikibase:wikiGroup>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="https://ru.wikipedia.org/wiki/%D0%9D%D0%B0%D1%82%D1%83%D1%80%D0%B0%D0%BB%D0%B8%D1%81">
+  <rdf:Description rdf:about="https://ru.wikipedia.org/wiki/%D0%9D%D0%B0%D1%82%D1%83%D1%80%D0%B0%D0%BB%D0%B8%D1%81">
     <rdf:type rdf:resource="http://schema.org/Article"/>
     <schema:about rdf:resource="http://www.wikidata.org/entity/Q641676"/>
     <schema:inLanguage>ru</schema:inLanguage>
@@ -234,11 +222,8 @@
     <wdt:P31 rdf:resource="http://www.wikidata.org/entity/Q31855"/>
     <wdt:P31 rdf:resource="http://www.wikidata.org/entity/Q17431399"/>
     <wdt:P31 rdf:resource="http://www.wikidata.org/entity/Q327333"/>
-    <wdt:P18
-      rdf:resource="http://commons.wikimedia.org/wiki/Special:FilePath/Naturalis-Leiden-2019-1.jpg"/>
-    <wdt:P625 rdf:datatype="http://www.opengis.net/ont/geosparql#wktLiteral">Point(4.47333333
-      52.16472222)
-    </wdt:P625>
+    <wdt:P18 rdf:resource="http://commons.wikimedia.org/wiki/Special:FilePath/Naturalis-Leiden-2019-1.jpg"/>
+    <wdt:P625 rdf:datatype="http://www.opengis.net/ont/geosparql#wktLiteral">Point(4.47333333 52.16472222)</wdt:P625>
     <wdt:P646>/m/08jgn7</wdt:P646>
     <wdtn:P646 rdf:resource="http://g.co/kg/m/08jgn7"/>
     <wdt:P227>5025979-9</wdt:P227>
@@ -259,8 +244,7 @@
     <wdt:P1365 rdf:resource="http://www.wikidata.org/entity/Q2045511"/>
     <wdt:P1365 rdf:resource="http://www.wikidata.org/entity/Q3432011"/>
     <wdt:P1365 rdf:resource="http://www.wikidata.org/entity/Q7333956"/>
-    <wdt:P571 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1984-01-01T00:00:00Z
-    </wdt:P571>
+    <wdt:P571 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1984-01-01T00:00:00Z</wdt:P571>
     <wdt:P2002>museumnaturalis</wdt:P2002>
     <wdt:P213>0000 0001 2159 802X</wdt:P213>
     <wdt:P3500>4503</wdt:P3500>
@@ -273,8 +257,7 @@
     <wdt:P1612>Naturalis</wdt:P1612>
     <wdt:P2427>grid.425948.6</wdt:P2427>
     <wdt:P1813 xml:lang="nl">RMNH</wdt:P1813>
-    <wdt:P1619 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1984-01-01T00:00:00Z
-    </wdt:P1619>
+    <wdt:P1619 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1984-01-01T00:00:00Z</wdt:P1619>
     <wdt:P2851 rdf:resource="http://www.wikidata.org/entity/Q2237462"/>
     <wdt:P2851 rdf:resource="http://www.wikidata.org/entity/Q58220185"/>
     <wdt:P281>2333 BA</wdt:P281>
@@ -310,309 +293,243 @@
     <wdt:P8272>204</wdt:P8272>
     <wdt:P7403>6141</wdt:P7403>
     <wdt:P6698>ナチュラリス生物多様性センター</wdt:P6698>
-    <wdtn:P6698
-      rdf:resource="https://jpsearch.go.jp/entity/chname/%E3%83%8A%E3%83%81%E3%83%A5%E3%83%A9%E3%83%AA%E3%82%B9%E7%94%9F%E7%89%A9%E5%A4%9A%E6%A7%98%E6%80%A7%E3%82%BB%E3%83%B3%E3%82%BF%E3%83%BC"/>
+    <wdtn:P6698 rdf:resource="https://jpsearch.go.jp/entity/chname/%E3%83%8A%E3%83%81%E3%83%A5%E3%83%A9%E3%83%AA%E3%82%B9%E7%94%9F%E7%89%A9%E5%A4%9A%E6%A7%98%E6%80%A7%E3%82%BB%E3%83%B3%E3%82%BF%E3%83%BC"/>
     <wdt:P7014 rdf:resource="http://bioportal.naturalis.nl/colofon"/>
     <wdt:P166 rdf:resource="http://www.wikidata.org/entity/Q1378151"/>
     <wdt:P3059>1799</wdt:P3059>
-    <p:P373
-      rdf:resource="http://www.wikidata.org/entity/statement/q641676-746BDEA8-85EC-4941-947A-3C7AD92F1F72"/>
+    <p:P373 rdf:resource="http://www.wikidata.org/entity/statement/q641676-746BDEA8-85EC-4941-947A-3C7AD92F1F72"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/q641676-746BDEA8-85EC-4941-947A-3C7AD92F1F72">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/q641676-746BDEA8-85EC-4941-947A-3C7AD92F1F72">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P373>Naturalis Leiden</ps:P373>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P17
-      rdf:resource="http://www.wikidata.org/entity/statement/q641676-D551CB2C-A011-447B-8070-25F9B7313C53"/>
+    <p:P17 rdf:resource="http://www.wikidata.org/entity/statement/q641676-D551CB2C-A011-447B-8070-25F9B7313C53"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/q641676-D551CB2C-A011-447B-8070-25F9B7313C53">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/q641676-D551CB2C-A011-447B-8070-25F9B7313C53">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P17 rdf:resource="http://www.wikidata.org/entity/Q55"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/732ec1c90a6f0694c7db9a71bf09fe7f2b674172"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/732ec1c90a6f0694c7db9a71bf09fe7f2b674172"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P131
-      rdf:resource="http://www.wikidata.org/entity/statement/q641676-F70AFA29-9982-4AD7-A683-AC613CC0CB9F"/>
+    <p:P131 rdf:resource="http://www.wikidata.org/entity/statement/q641676-F70AFA29-9982-4AD7-A683-AC613CC0CB9F"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/q641676-F70AFA29-9982-4AD7-A683-AC613CC0CB9F">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/q641676-F70AFA29-9982-4AD7-A683-AC613CC0CB9F">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P131 rdf:resource="http://www.wikidata.org/entity/Q43631"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/732ec1c90a6f0694c7db9a71bf09fe7f2b674172"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/732ec1c90a6f0694c7db9a71bf09fe7f2b674172"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P31
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-AABF0157-DB41-4F39-8B17-76BFCAD424AA"/>
+    <p:P31 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-AABF0157-DB41-4F39-8B17-76BFCAD424AA"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-AABF0157-DB41-4F39-8B17-76BFCAD424AA">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-AABF0157-DB41-4F39-8B17-76BFCAD424AA">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P31 rdf:resource="http://www.wikidata.org/entity/Q31855"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P31
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-A3ED887F-5CE1-4BFD-9A07-520E26F97AC1"/>
+    <p:P31 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-A3ED887F-5CE1-4BFD-9A07-520E26F97AC1"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-A3ED887F-5CE1-4BFD-9A07-520E26F97AC1">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-A3ED887F-5CE1-4BFD-9A07-520E26F97AC1">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P31 rdf:resource="http://www.wikidata.org/entity/Q17431399"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P31
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-a252b3b7-44c7-c38c-c569-0ed030ce95a8"/>
+    <p:P31 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-a252b3b7-44c7-c38c-c569-0ed030ce95a8"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-a252b3b7-44c7-c38c-c569-0ed030ce95a8">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-a252b3b7-44c7-c38c-c569-0ed030ce95a8">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P31 rdf:resource="http://www.wikidata.org/entity/Q327333"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P18
-      rdf:resource="http://www.wikidata.org/entity/statement/q641676-F880F1F3-64C5-40C1-8343-2A43B6CC03BC"/>
+    <p:P18 rdf:resource="http://www.wikidata.org/entity/statement/q641676-F880F1F3-64C5-40C1-8343-2A43B6CC03BC"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/q641676-F880F1F3-64C5-40C1-8343-2A43B6CC03BC">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/q641676-F880F1F3-64C5-40C1-8343-2A43B6CC03BC">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
-    <ps:P18
-      rdf:resource="http://commons.wikimedia.org/wiki/Special:FilePath/Naturalis-Leiden-2019-1.jpg"/>
+    <ps:P18 rdf:resource="http://commons.wikimedia.org/wiki/Special:FilePath/Naturalis-Leiden-2019-1.jpg"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P625
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-AD78C520-879C-4637-9A3B-764616A82BD9"/>
+    <p:P625 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-AD78C520-879C-4637-9A3B-764616A82BD9"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-AD78C520-879C-4637-9A3B-764616A82BD9">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-AD78C520-879C-4637-9A3B-764616A82BD9">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
-    <ps:P625 rdf:datatype="http://www.opengis.net/ont/geosparql#wktLiteral">Point(4.47333333
-      52.16472222)
-    </ps:P625>
+    <ps:P625 rdf:datatype="http://www.opengis.net/ont/geosparql#wktLiteral">Point(4.47333333 52.16472222)</ps:P625>
     <psv:P625 rdf:resource="http://www.wikidata.org/value/29700b6a1745ff311229e30533e81777"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/9a24f7c0208b05d6be97077d855671d1dfdbc0dd"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/9a24f7c0208b05d6be97077d855671d1dfdbc0dd"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P646
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-47A8CC02-373E-4AAF-834D-565D51B366B8"/>
+    <p:P646 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-47A8CC02-373E-4AAF-834D-565D51B366B8"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-47A8CC02-373E-4AAF-834D-565D51B366B8">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-47A8CC02-373E-4AAF-834D-565D51B366B8">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P646>/m/08jgn7</ps:P646>
     <psn:P646 rdf:resource="http://g.co/kg/m/08jgn7"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/2b00cb481cddcac7623114367489b5c194901c4a"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/2b00cb481cddcac7623114367489b5c194901c4a"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P227
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-DB1AB114-35A3-4981-80B1-C11C7A437CA4"/>
+    <p:P227 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-DB1AB114-35A3-4981-80B1-C11C7A437CA4"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-DB1AB114-35A3-4981-80B1-C11C7A437CA4">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-DB1AB114-35A3-4981-80B1-C11C7A437CA4">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P227>5025979-9</ps:P227>
     <psn:P227 rdf:resource="https://d-nb.info/gnd/5025979-9"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/9a24f7c0208b05d6be97077d855671d1dfdbc0dd"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/9a24f7c0208b05d6be97077d855671d1dfdbc0dd"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P488
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-02AE71BE-3274-4B49-9784-6190340417CD"/>
+    <p:P488 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-02AE71BE-3274-4B49-9784-6190340417CD"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-02AE71BE-3274-4B49-9784-6190340417CD">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-02AE71BE-3274-4B49-9784-6190340417CD">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P488 rdf:resource="http://www.wikidata.org/entity/Q2132224"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/fa278ebfc458360e5aed63d5058cca83c46134f1"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/fa278ebfc458360e5aed63d5058cca83c46134f1"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P856
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-08E048FA-3D41-4313-8690-B5EBBAE6EC48"/>
+    <p:P856 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-08E048FA-3D41-4313-8690-B5EBBAE6EC48"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-08E048FA-3D41-4313-8690-B5EBBAE6EC48">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-08E048FA-3D41-4313-8690-B5EBBAE6EC48">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P856 rdf:resource="http://www.naturalis.nl"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/fa278ebfc458360e5aed63d5058cca83c46134f1"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/fa278ebfc458360e5aed63d5058cca83c46134f1"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P1174
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-3C0ECDA8-D135-45E1-903E-18AB1424DE4C"/>
+    <p:P1174 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-3C0ECDA8-D135-45E1-903E-18AB1424DE4C"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-3C0ECDA8-D135-45E1-903E-18AB1424DE4C">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-3C0ECDA8-D135-45E1-903E-18AB1424DE4C">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P1174 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">+271000</ps:P1174>
     <psv:P1174 rdf:resource="http://www.wikidata.org/value/df2e3e6ccf622e2f0ebb5ed187399afd"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/fa278ebfc458360e5aed63d5058cca83c46134f1"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/fa278ebfc458360e5aed63d5058cca83c46134f1"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P214
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-B8617EBD-A02E-477D-9488-2F33F7C4387E"/>
+    <p:P214 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-B8617EBD-A02E-477D-9488-2F33F7C4387E"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-B8617EBD-A02E-477D-9488-2F33F7C4387E">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-B8617EBD-A02E-477D-9488-2F33F7C4387E">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P214>132063008</ps:P214>
     <psn:P214 rdf:resource="http://viaf.org/viaf/132063008"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/9a24f7c0208b05d6be97077d855671d1dfdbc0dd"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/9a24f7c0208b05d6be97077d855671d1dfdbc0dd"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P214
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-EFBEF7D1-42B2-4C04-AA21-580711D5DB37"/>
+    <p:P214 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-EFBEF7D1-42B2-4C04-AA21-580711D5DB37"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-EFBEF7D1-42B2-4C04-AA21-580711D5DB37">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-EFBEF7D1-42B2-4C04-AA21-580711D5DB37">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P214>305227246</ps:P214>
     <psn:P214 rdf:resource="http://viaf.org/viaf/305227246"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/2d1bdb40c9ef573a185deaf8ac541b5a7a1d1575"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/2d1bdb40c9ef573a185deaf8ac541b5a7a1d1575"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P244
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-4BF346D7-5547-4591-AAED-BE7D4D58F971"/>
+    <p:P244 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-4BF346D7-5547-4591-AAED-BE7D4D58F971"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-4BF346D7-5547-4591-AAED-BE7D4D58F971">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-4BF346D7-5547-4591-AAED-BE7D4D58F971">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P244>n92025427</ps:P244>
     <psn:P244 rdf:resource="https://id.loc.gov/authorities/names/n92025427"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/9a24f7c0208b05d6be97077d855671d1dfdbc0dd"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/9a24f7c0208b05d6be97077d855671d1dfdbc0dd"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P1305
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-F07C0874-FF3A-445E-A729-A439D25C00D4"/>
+    <p:P1305 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-F07C0874-FF3A-445E-A729-A439D25C00D4"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-F07C0874-FF3A-445E-A729-A439D25C00D4">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-F07C0874-FF3A-445E-A729-A439D25C00D4">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P1305>6544</ps:P1305>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/cfc3fc925ddc31f71c67244753346f9fca7ab7d7"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/cfc3fc925ddc31f71c67244753346f9fca7ab7d7"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P269
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-4B0E0F60-E46F-4CCE-A2DD-74428EEBD5E1"/>
+    <p:P269 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-4B0E0F60-E46F-4CCE-A2DD-74428EEBD5E1"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-4B0E0F60-E46F-4CCE-A2DD-74428EEBD5E1">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-4B0E0F60-E46F-4CCE-A2DD-74428EEBD5E1">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P269>157896315</ps:P269>
     <psn:P269 rdf:resource="http://www.idref.fr/157896315/id"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/4533e325b4161189dcba02b6a92f6c4533327637"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/4533e325b4161189dcba02b6a92f6c4533327637"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P1365
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-4252ecfc-4ce8-a2c6-4de5-432e8732d5f7"/>
+    <p:P1365 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-4252ecfc-4ce8-a2c6-4de5-432e8732d5f7"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-4252ecfc-4ce8-a2c6-4de5-432e8732d5f7">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-4252ecfc-4ce8-a2c6-4de5-432e8732d5f7">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P1365 rdf:resource="http://www.wikidata.org/entity/Q3924939"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P1365
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-692b9780-4463-d3d0-ac34-db7c16f45e2f"/>
+    <p:P1365 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-692b9780-4463-d3d0-ac34-db7c16f45e2f"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-692b9780-4463-d3d0-ac34-db7c16f45e2f">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-692b9780-4463-d3d0-ac34-db7c16f45e2f">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P1365 rdf:resource="http://www.wikidata.org/entity/Q2045511"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P1365
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-163bd2f8-4ec4-b86f-527d-4748e4f7b354"/>
+    <p:P1365 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-163bd2f8-4ec4-b86f-527d-4748e4f7b354"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-163bd2f8-4ec4-b86f-527d-4748e4f7b354">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-163bd2f8-4ec4-b86f-527d-4748e4f7b354">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P1365 rdf:resource="http://www.wikidata.org/entity/Q3432011"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P1365
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-f3f3bab4-4dd0-bf3a-d1d6-6771ffb68cde"/>
+    <p:P1365 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-f3f3bab4-4dd0-bf3a-d1d6-6771ffb68cde"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-f3f3bab4-4dd0-bf3a-d1d6-6771ffb68cde">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-f3f3bab4-4dd0-bf3a-d1d6-6771ffb68cde">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P1365 rdf:resource="http://www.wikidata.org/entity/Q7333956"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P571
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-14D63BC6-81BC-4C75-89FB-A53A35305399"/>
+    <p:P571 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-14D63BC6-81BC-4C75-89FB-A53A35305399"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-14D63BC6-81BC-4C75-89FB-A53A35305399">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-14D63BC6-81BC-4C75-89FB-A53A35305399">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P571 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1984-01-01T00:00:00Z</ps:P571>
     <psv:P571 rdf:resource="http://www.wikidata.org/value/eb0a73e8075db328523be97d99b44c4d"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/fa278ebfc458360e5aed63d5058cca83c46134f1"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/fa278ebfc458360e5aed63d5058cca83c46134f1"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P2002
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-13BFA294-C4DE-40EE-A77A-D33C8C72217A"/>
+    <p:P2002 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-13BFA294-C4DE-40EE-A77A-D33C8C72217A"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-13BFA294-C4DE-40EE-A77A-D33C8C72217A">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-13BFA294-C4DE-40EE-A77A-D33C8C72217A">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
@@ -624,314 +541,249 @@
     <pqv:P585 rdf:resource="http://www.wikidata.org/value/d6393f334ebb1e3e38651406f16c1a39"/>
     <pq:P580 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2008-09-08T00:00:00Z</pq:P580>
     <pqv:P580 rdf:resource="http://www.wikidata.org/value/0f06e57ad4e5a1b8274594f8c83ff0e4"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/bdc392da4402f32ffe5912f6f5d0413e12c781c0"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/bdc392da4402f32ffe5912f6f5d0413e12c781c0"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P213
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-B8C50F38-E515-4AD7-A010-96D843484408"/>
+    <p:P213 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-B8C50F38-E515-4AD7-A010-96D843484408"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-B8C50F38-E515-4AD7-A010-96D843484408">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-B8C50F38-E515-4AD7-A010-96D843484408">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P213>0000 0001 2159 802X</ps:P213>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/f20e7cc1dc95f8af90470df9ddea266baf12be00"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/f20e7cc1dc95f8af90470df9ddea266baf12be00"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P3500
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-E38E6CEF-A7A1-42AC-A96C-EC7A6BE31667"/>
+    <p:P3500 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-E38E6CEF-A7A1-42AC-A96C-EC7A6BE31667"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-E38E6CEF-A7A1-42AC-A96C-EC7A6BE31667">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-E38E6CEF-A7A1-42AC-A96C-EC7A6BE31667">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P3500>4503</ps:P3500>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/45e8fa2e37c421b7e5970029041dbdeac9824284"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/45e8fa2e37c421b7e5970029041dbdeac9824284"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P2657
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-DD1793BB-3683-4729-8E26-4257145F2A0A"/>
+    <p:P2657 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-DD1793BB-3683-4729-8E26-4257145F2A0A"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-DD1793BB-3683-4729-8E26-4257145F2A0A">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-DD1793BB-3683-4729-8E26-4257145F2A0A">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P2657>07658399914-37</ps:P2657>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P3793
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-30C92027-A628-45C2-A5B7-02C53D5DE696"/>
+    <p:P3793 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-30C92027-A628-45C2-A5B7-02C53D5DE696"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-30C92027-A628-45C2-A5B7-02C53D5DE696">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-30C92027-A628-45C2-A5B7-02C53D5DE696">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P3793>2001:610:1910::/48</ps:P3793>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/0922b18cbd5b72d3cb146c310184634e70883a6d"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/0922b18cbd5b72d3cb146c310184634e70883a6d"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P3273
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-1440D0F8-DE60-4B85-83C3-7FFE8E2F9F1A"/>
+    <p:P3273 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-1440D0F8-DE60-4B85-83C3-7FFE8E2F9F1A"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-1440D0F8-DE60-4B85-83C3-7FFE8E2F9F1A">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-1440D0F8-DE60-4B85-83C3-7FFE8E2F9F1A">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P3273>15a89db0-d6fd-410a-8181-ad7b1d4d9d6b</ps:P3273>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P1315
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-2984A804-398B-4285-8087-CDFE5E62D7D4"/>
+    <p:P1315 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-2984A804-398B-4285-8087-CDFE5E62D7D4"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-2984A804-398B-4285-8087-CDFE5E62D7D4">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-2984A804-398B-4285-8087-CDFE5E62D7D4">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P1315>1059500</ps:P1315>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P1662
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-32DEA0CB-F3AD-40CA-B516-98BFAB29667F"/>
+    <p:P1662 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-32DEA0CB-F3AD-40CA-B516-98BFAB29667F"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-32DEA0CB-F3AD-40CA-B516-98BFAB29667F">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-32DEA0CB-F3AD-40CA-B516-98BFAB29667F">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P1662>10.3767</ps:P1662>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/fcb7e912b5609935e9aab460323fd4b0050ab3bf"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/fcb7e912b5609935e9aab460323fd4b0050ab3bf"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P4702
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-656598A7-F7EA-4D10-9213-B4E4434119BB"/>
+    <p:P4702 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-656598A7-F7EA-4D10-9213-B4E4434119BB"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-656598A7-F7EA-4D10-9213-B4E4434119BB">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-656598A7-F7EA-4D10-9213-B4E4434119BB">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P4702>naturalis-biodiversity-center</ps:P4702>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/fa278ebfc458360e5aed63d5058cca83c46134f1"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/fa278ebfc458360e5aed63d5058cca83c46134f1"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P1612
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-3f1ac7a9-4a95-d064-a893-227a8d19f8a1"/>
+    <p:P1612 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-3f1ac7a9-4a95-d064-a893-227a8d19f8a1"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-3f1ac7a9-4a95-d064-a893-227a8d19f8a1">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-3f1ac7a9-4a95-d064-a893-227a8d19f8a1">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P1612>Naturalis</ps:P1612>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P2427
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-85B0CBAC-E07A-4F06-B610-F26E9E7C9D59"/>
+    <p:P2427 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-85B0CBAC-E07A-4F06-B610-F26E9E7C9D59"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-85B0CBAC-E07A-4F06-B610-F26E9E7C9D59">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-85B0CBAC-E07A-4F06-B610-F26E9E7C9D59">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P2427>grid.425948.6</ps:P2427>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/40fdc7f3ce7f6771a8f285a1267bfc3f3de154d9"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/a1914c8952a5bc482eafeb26be4fda504fe701f9"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/40fdc7f3ce7f6771a8f285a1267bfc3f3de154d9"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/a1914c8952a5bc482eafeb26be4fda504fe701f9"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P1813
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-8e89c4ba-4357-0f3c-9a29-e96ae81e7cf2"/>
+    <p:P1813 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-8e89c4ba-4357-0f3c-9a29-e96ae81e7cf2"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-8e89c4ba-4357-0f3c-9a29-e96ae81e7cf2">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-8e89c4ba-4357-0f3c-9a29-e96ae81e7cf2">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P1813 xml:lang="nl">RMNH</ps:P1813>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P1619
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-B1395CFD-88B3-4113-8582-116FC39CFD6D"/>
+    <p:P1619 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-B1395CFD-88B3-4113-8582-116FC39CFD6D"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-B1395CFD-88B3-4113-8582-116FC39CFD6D">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-B1395CFD-88B3-4113-8582-116FC39CFD6D">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
-    <ps:P1619 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1984-01-01T00:00:00Z
-    </ps:P1619>
+    <ps:P1619 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1984-01-01T00:00:00Z</ps:P1619>
     <psv:P1619 rdf:resource="http://www.wikidata.org/value/eb0a73e8075db328523be97d99b44c4d"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/f507edf93a227371b28a18269a56a7189f6d43f3"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/f507edf93a227371b28a18269a56a7189f6d43f3"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P2851
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-F0358F1C-D4E5-4471-A46F-E230D0F31FA8"/>
+    <p:P2851 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-F0358F1C-D4E5-4471-A46F-E230D0F31FA8"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-F0358F1C-D4E5-4471-A46F-E230D0F31FA8">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-F0358F1C-D4E5-4471-A46F-E230D0F31FA8">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P2851 rdf:resource="http://www.wikidata.org/entity/Q2237462"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/56da4ad0e0d7110e28d9c4ee68beeb3d9db64008"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/56da4ad0e0d7110e28d9c4ee68beeb3d9db64008"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P2851
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-1772e3d1-4e91-d790-f499-3a18be3fa1ab"/>
+    <p:P2851 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-1772e3d1-4e91-d790-f499-3a18be3fa1ab"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-1772e3d1-4e91-d790-f499-3a18be3fa1ab">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-1772e3d1-4e91-d790-f499-3a18be3fa1ab">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P2851 rdf:resource="http://www.wikidata.org/entity/Q58220185"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/0ba1dd7ba8fa48f5efddf6c41b2c39949c8854ae"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/0ba1dd7ba8fa48f5efddf6c41b2c39949c8854ae"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P281
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-FB31E0A9-9BEA-40F6-936B-3205B6DF180C"/>
+    <p:P281 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-FB31E0A9-9BEA-40F6-936B-3205B6DF180C"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-FB31E0A9-9BEA-40F6-936B-3205B6DF180C">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-FB31E0A9-9BEA-40F6-936B-3205B6DF180C">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P281>2333 BA</ps:P281>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P1329
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-BE993B4E-FAA4-4220-BCB0-AEE3625AB1CA"/>
+    <p:P1329 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-BE993B4E-FAA4-4220-BCB0-AEE3625AB1CA"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-BE993B4E-FAA4-4220-BCB0-AEE3625AB1CA">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-BE993B4E-FAA4-4220-BCB0-AEE3625AB1CA">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P1329>+31-71-751-9600</ps:P1329>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P973
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-2CEC0B1D-5E18-4FC7-9847-A7F12E0748A7"/>
+    <p:P973 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-2CEC0B1D-5E18-4FC7-9847-A7F12E0748A7"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-2CEC0B1D-5E18-4FC7-9847-A7F12E0748A7">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-2CEC0B1D-5E18-4FC7-9847-A7F12E0748A7">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P973 rdf:resource="https://www.museumkaart.nl/museum/Naturalis.aspx"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/de93c5991fe66e1f3ea65ffd7ef6af8084d830a4"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/de93c5991fe66e1f3ea65ffd7ef6af8084d830a4"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P355
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-9B46A8BD-42E7-4BCE-87C9-A0D119BCE58D"/>
+    <p:P355 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-9B46A8BD-42E7-4BCE-87C9-A0D119BCE58D"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-9B46A8BD-42E7-4BCE-87C9-A0D119BCE58D">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-9B46A8BD-42E7-4BCE-87C9-A0D119BCE58D">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P355 rdf:resource="http://www.wikidata.org/entity/Q55829291"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P1830
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-7643D79A-9870-4208-93E8-59445EDA90D8"/>
+    <p:P1830 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-7643D79A-9870-4208-93E8-59445EDA90D8"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-7643D79A-9870-4208-93E8-59445EDA90D8">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-7643D79A-9870-4208-93E8-59445EDA90D8">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P1830 rdf:resource="http://www.wikidata.org/entity/Q2246990"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P6155
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-B60B7397-8757-4EEE-A55E-2C8449B261DF"/>
+    <p:P6155 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-B60B7397-8757-4EEE-A55E-2C8449B261DF"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-B60B7397-8757-4EEE-A55E-2C8449B261DF">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-B60B7397-8757-4EEE-A55E-2C8449B261DF">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P6155>naturalis-biodiversity-centre</ps:P6155>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P4090
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-9990a6f0-41b4-cc8e-afd4-703480c3d5f0"/>
+    <p:P4090 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-9990a6f0-41b4-cc8e-afd4-703480c3d5f0"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-9990a6f0-41b4-cc8e-afd4-703480c3d5f0">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-9990a6f0-41b4-cc8e-afd4-703480c3d5f0">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P4090>NBC</ps:P4090>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P4090
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-abb3e011-448b-1641-d97e-7f0920c34c0d"/>
+    <p:P4090 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-abb3e011-448b-1641-d97e-7f0920c34c0d"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-abb3e011-448b-1641-d97e-7f0920c34c0d">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-abb3e011-448b-1641-d97e-7f0920c34c0d">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P4090>NNML</ps:P4090>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P4090
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-b03a1434-493a-231d-83d4-f9c843410f14"/>
+    <p:P4090 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-b03a1434-493a-231d-83d4-f9c843410f14"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-b03a1434-493a-231d-83d4-f9c843410f14">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-b03a1434-493a-231d-83d4-f9c843410f14">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P4090>NCB</ps:P4090>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P4090
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-07739820-4be9-1cc4-ea88-f5258c8ad2ce"/>
+    <p:P4090 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-07739820-4be9-1cc4-ea88-f5258c8ad2ce"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-07739820-4be9-1cc4-ea88-f5258c8ad2ce">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-07739820-4be9-1cc4-ea88-f5258c8ad2ce">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P4090>NNM</ps:P4090>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P6782
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-998AD3A2-4B88-44F9-9A2E-7FB4A48322B4"/>
+    <p:P6782 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-998AD3A2-4B88-44F9-9A2E-7FB4A48322B4"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-998AD3A2-4B88-44F9-9A2E-7FB4A48322B4">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-998AD3A2-4B88-44F9-9A2E-7FB4A48322B4">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P6782>0566bfb96</ps:P6782>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P84
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-d1e9d8c8-447d-9f45-5bd4-b3b21703f3b1"/>
+    <p:P84 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-d1e9d8c8-447d-9f45-5bd4-b3b21703f3b1"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-d1e9d8c8-447d-9f45-5bd4-b3b21703f3b1">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-d1e9d8c8-447d-9f45-5bd4-b3b21703f3b1">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
@@ -939,28 +791,22 @@
     <pq:P518 rdf:resource="http://www.wikidata.org/entity/Q19841649"/>
     <pq:P580 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-01T00:00:00Z</pq:P580>
     <pqv:P580 rdf:resource="http://www.wikidata.org/value/1c9551a398cfb51623c28b80416004d3"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/091310947d434f969669d6f86877179ab49df8b5"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/091310947d434f969669d6f86877179ab49df8b5"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P84
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-688ed6b1-428f-e8fd-d4ef-150e388cf7f0"/>
+    <p:P84 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-688ed6b1-428f-e8fd-d4ef-150e388cf7f0"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-688ed6b1-428f-e8fd-d4ef-150e388cf7f0">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-688ed6b1-428f-e8fd-d4ef-150e388cf7f0">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P84 rdf:resource="http://www.wikidata.org/entity/Q2494745"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/4a86fdea19c76da6803f71b49648769d3e6448a1"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/4a86fdea19c76da6803f71b49648769d3e6448a1"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P1343
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-41CECB1E-085C-4025-8305-298705930961"/>
+    <p:P1343 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-41CECB1E-085C-4025-8305-298705930961"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-41CECB1E-085C-4025-8305-298705930961">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-41CECB1E-085C-4025-8305-298705930961">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
@@ -971,19 +817,14 @@
     <pqv:P585 rdf:resource="http://www.wikidata.org/value/0c5f07ea6b6e92dd89849b978518123d"/>
     <pq:P585 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-03T00:00:00Z</pq:P585>
     <pqv:P585 rdf:resource="http://www.wikidata.org/value/b3eedd3c3bfc9343bcd60b5430dc341d"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/0e3b48ffd16176acaf88177cd865f1e389084c77"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/1f94b9fc199ff31be06b906fd8ec1e9043866ba2"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/5119aea74673e8aa798b0743e236d70ba0a0e644"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/0e3b48ffd16176acaf88177cd865f1e389084c77"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/1f94b9fc199ff31be06b906fd8ec1e9043866ba2"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/5119aea74673e8aa798b0743e236d70ba0a0e644"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P6366
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-1513B913-5A57-4AEB-92F6-1DF36C7F697C"/>
+    <p:P6366 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-1513B913-5A57-4AEB-92F6-1DF36C7F697C"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-1513B913-5A57-4AEB-92F6-1DF36C7F697C">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-1513B913-5A57-4AEB-92F6-1DF36C7F697C">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
@@ -991,113 +832,88 @@
     <psn:P6366 rdf:resource="http://ma-graph.org/entity/1295562517"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P463
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-7ad31fc2-4c12-1fa4-fd98-dae03e8a465e"/>
+    <p:P463 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-7ad31fc2-4c12-1fa4-fd98-dae03e8a465e"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-7ad31fc2-4c12-1fa4-fd98-dae03e8a465e">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-7ad31fc2-4c12-1fa4-fd98-dae03e8a465e">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P463 rdf:resource="http://www.wikidata.org/entity/Q5163385"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/6e34c4992adc896790754535d2dd43cafaf9bebe"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/6e34c4992adc896790754535d2dd43cafaf9bebe"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P463
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-9e4dbe84-461a-e37f-0fa7-6bbb79023cb7"/>
+    <p:P463 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-9e4dbe84-461a-e37f-0fa7-6bbb79023cb7"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-9e4dbe84-461a-e37f-0fa7-6bbb79023cb7">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-9e4dbe84-461a-e37f-0fa7-6bbb79023cb7">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P463 rdf:resource="http://www.wikidata.org/entity/Q4914768"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/3693dee5af6ce7807b747a592c25c6c7d68c180d"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/3693dee5af6ce7807b747a592c25c6c7d68c180d"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P463
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-080677D4-379C-404A-A691-90458A032440"/>
+    <p:P463 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-080677D4-379C-404A-A691-90458A032440"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-080677D4-379C-404A-A691-90458A032440">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-080677D4-379C-404A-A691-90458A032440">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P463 rdf:resource="http://www.wikidata.org/entity/Q1991604"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/07d727fd8f1a3903c1acfb8fae6a2cd6461219d8"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/07d727fd8f1a3903c1acfb8fae6a2cd6461219d8"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P4081
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-370D3CF2-1BE9-4CFE-9C2B-B314B693FDA8"/>
+    <p:P4081 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-370D3CF2-1BE9-4CFE-9C2B-B314B693FDA8"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-370D3CF2-1BE9-4CFE-9C2B-B314B693FDA8">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-370D3CF2-1BE9-4CFE-9C2B-B314B693FDA8">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P4081>235435</ps:P4081>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P7859
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-589B2B74-3591-4101-AB97-17C7E508E40D"/>
+    <p:P7859 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-589B2B74-3591-4101-AB97-17C7E508E40D"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-589B2B74-3591-4101-AB97-17C7E508E40D">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-589B2B74-3591-4101-AB97-17C7E508E40D">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P7859>lccn-n92025427</ps:P7859>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/b72b0c69b9ff36a930131ec263e7241d36a097c0"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/b72b0c69b9ff36a930131ec263e7241d36a097c0"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P7859
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-FA848053-9B0A-4AB8-89FA-E273648E5D7E"/>
+    <p:P7859 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-FA848053-9B0A-4AB8-89FA-E273648E5D7E"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-FA848053-9B0A-4AB8-89FA-E273648E5D7E">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-FA848053-9B0A-4AB8-89FA-E273648E5D7E">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P7859>lccn-nb2015013309</ps:P7859>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/9388e42c81d6c0e9f013d673a876f6c72c8ba686"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/9388e42c81d6c0e9f013d673a876f6c72c8ba686"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P2013
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-e041075f-4db4-0c72-0ae8-9aabc3c4d790"/>
+    <p:P2013 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-e041075f-4db4-0c72-0ae8-9aabc3c4d790"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-e041075f-4db4-0c72-0ae8-9aabc3c4d790">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-e041075f-4db4-0c72-0ae8-9aabc3c4d790">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P2013>museumnaturalis</ps:P2013>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/bdc392da4402f32ffe5912f6f5d0413e12c781c0"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/bdc392da4402f32ffe5912f6f5d0413e12c781c0"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P2003
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-d14415c8-4e25-64e0-33fb-5012b98817b7"/>
+    <p:P2003 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-d14415c8-4e25-64e0-33fb-5012b98817b7"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-d14415c8-4e25-64e0-33fb-5012b98817b7">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-d14415c8-4e25-64e0-33fb-5012b98817b7">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P2003>naturalismuseum</ps:P2003>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/bdc392da4402f32ffe5912f6f5d0413e12c781c0"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/bdc392da4402f32ffe5912f6f5d0413e12c781c0"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P2397
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-dd823047-4832-0c4e-9bfc-a62923ab56d6"/>
+    <p:P2397 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-dd823047-4832-0c4e-9bfc-a62923ab56d6"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-dd823047-4832-0c4e-9bfc-a62923ab56d6">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-dd823047-4832-0c4e-9bfc-a62923ab56d6">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
@@ -1113,53 +929,42 @@
     <pqv:P5436 rdf:resource="http://www.wikidata.org/value/3bc1e9007990add52c8fb597b5e96bb6"/>
     <pq:P585 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-11T00:00:00Z</pq:P585>
     <pqv:P585 rdf:resource="http://www.wikidata.org/value/3c3accbb8e91a57dbeeb9d654628cd1a"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/bdc392da4402f32ffe5912f6f5d0413e12c781c0"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/bdc392da4402f32ffe5912f6f5d0413e12c781c0"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P6269
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-2AB33A64-21F7-47B4-89D8-5F9B4D127D06"/>
+    <p:P6269 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-2AB33A64-21F7-47B4-89D8-5F9B4D127D06"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-2AB33A64-21F7-47B4-89D8-5F9B4D127D06">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-2AB33A64-21F7-47B4-89D8-5F9B4D127D06">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P6269 rdf:resource="http://adfs.naturalis.nl/adfs/services/trust"/>
     <pq:P2700 rdf:resource="http://www.wikidata.org/entity/Q458022"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/19f351fefd610a866859a3ffe6a2a2413936521f"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/19f351fefd610a866859a3ffe6a2a2413936521f"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P1705
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-ec963ee1-4ec0-463c-2aca-8a442591413b"/>
+    <p:P1705 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-ec963ee1-4ec0-463c-2aca-8a442591413b"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-ec963ee1-4ec0-463c-2aca-8a442591413b">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-ec963ee1-4ec0-463c-2aca-8a442591413b">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P1705 xml:lang="nl">Nederlands Centrum voor Biodiversiteit Naturalis</ps:P1705>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/40462db33d6dce09bcb5b80684506375f6013475"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/40462db33d6dce09bcb5b80684506375f6013475"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P8464
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-e63c978d-a53d-464a-b133-4aa4eaf299c6"/>
+    <p:P8464 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-e63c978d-a53d-464a-b133-4aa4eaf299c6"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-e63c978d-a53d-464a-b133-4aa4eaf299c6">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-e63c978d-a53d-464a-b133-4aa4eaf299c6">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P8464 rdf:resource="http://www.wikidata.org/entity/Q97584168"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P8687
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-57ba2276-4437-479b-b84f-1d984766149c"/>
+    <p:P8687 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-57ba2276-4437-479b-b84f-1d984766149c"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-57ba2276-4437-479b-b84f-1d984766149c">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-57ba2276-4437-479b-b84f-1d984766149c">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#PreferredRank"/>
@@ -1170,11 +975,9 @@
     <pqv:P585 rdf:resource="http://www.wikidata.org/value/d40cb13acf8001d779efbb0c45cb42f0"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P8687
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-d3b46786-1e74-4ff1-bda7-ff0b404e38ff"/>
+    <p:P8687 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-d3b46786-1e74-4ff1-bda7-ff0b404e38ff"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-d3b46786-1e74-4ff1-bda7-ff0b404e38ff">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-d3b46786-1e74-4ff1-bda7-ff0b404e38ff">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P8687 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">+12878</ps:P8687>
@@ -1184,72 +987,57 @@
     <pqv:P585 rdf:resource="http://www.wikidata.org/value/d6393f334ebb1e3e38651406f16c1a39"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P1870
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-11A17D24-C7F6-49F6-8865-253ABFDD06CB"/>
+    <p:P1870 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-11A17D24-C7F6-49F6-8865-253ABFDD06CB"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-11A17D24-C7F6-49F6-8865-253ABFDD06CB">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-11A17D24-C7F6-49F6-8865-253ABFDD06CB">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P1870>54722</ps:P1870>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/838150ba9d3e26e34caf47b0a92a34049a1421e2"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/838150ba9d3e26e34caf47b0a92a34049a1421e2"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P8272
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-A55BC144-37FD-49A6-89D4-0E9FBED85596"/>
+    <p:P8272 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-A55BC144-37FD-49A6-89D4-0E9FBED85596"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-A55BC144-37FD-49A6-89D4-0E9FBED85596">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-A55BC144-37FD-49A6-89D4-0E9FBED85596">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P8272>204</ps:P8272>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P7403
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-D0565195-F51B-42CB-BEB1-CC65310DE11A"/>
+    <p:P7403 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-D0565195-F51B-42CB-BEB1-CC65310DE11A"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-D0565195-F51B-42CB-BEB1-CC65310DE11A">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-D0565195-F51B-42CB-BEB1-CC65310DE11A">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P7403>6141</ps:P7403>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P6698
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-6B13975A-30DD-416F-97F8-5E97A819C3DB"/>
+    <p:P6698 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-6B13975A-30DD-416F-97F8-5E97A819C3DB"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-6B13975A-30DD-416F-97F8-5E97A819C3DB">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-6B13975A-30DD-416F-97F8-5E97A819C3DB">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P6698>ナチュラリス生物多様性センター</ps:P6698>
-    <psn:P6698
-      rdf:resource="https://jpsearch.go.jp/entity/chname/%E3%83%8A%E3%83%81%E3%83%A5%E3%83%A9%E3%83%AA%E3%82%B9%E7%94%9F%E7%89%A9%E5%A4%9A%E6%A7%98%E6%80%A7%E3%82%BB%E3%83%B3%E3%82%BF%E3%83%BC"/>
+    <psn:P6698 rdf:resource="https://jpsearch.go.jp/entity/chname/%E3%83%8A%E3%83%81%E3%83%A5%E3%83%A9%E3%83%AA%E3%82%B9%E7%94%9F%E7%89%A9%E5%A4%9A%E6%A7%98%E6%80%A7%E3%82%BB%E3%83%B3%E3%82%BF%E3%83%BC"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P7014
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-CD3CF795-7878-4DB6-BA9C-45942A817AB0"/>
+    <p:P7014 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-CD3CF795-7878-4DB6-BA9C-45942A817AB0"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-CD3CF795-7878-4DB6-BA9C-45942A817AB0">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-CD3CF795-7878-4DB6-BA9C-45942A817AB0">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
     <ps:P7014 rdf:resource="http://bioportal.naturalis.nl/colofon"/>
-    <prov:wasDerivedFrom
-      rdf:resource="http://www.wikidata.org/reference/a73243e27f42de75ca85e1ac6b082e8f3c7e89f9"/>
+    <prov:wasDerivedFrom rdf:resource="http://www.wikidata.org/reference/a73243e27f42de75ca85e1ac6b082e8f3c7e89f9"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P166
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-62ba6640-4ef3-9397-bf7b-c93b49a63362"/>
+    <p:P166 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-62ba6640-4ef3-9397-bf7b-c93b49a63362"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-62ba6640-4ef3-9397-bf7b-c93b49a63362">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-62ba6640-4ef3-9397-bf7b-c93b49a63362">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
@@ -1258,11 +1046,9 @@
     <pqv:P585 rdf:resource="http://www.wikidata.org/value/068defc300d06ed22eb72f44c2fe8914"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q641676">
-    <p:P3059
-      rdf:resource="http://www.wikidata.org/entity/statement/Q641676-1439BE45-49E0-46A7-89C6-1868133736BE"/>
+    <p:P3059 rdf:resource="http://www.wikidata.org/entity/statement/Q641676-1439BE45-49E0-46A7-89C6-1868133736BE"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/entity/statement/Q641676-1439BE45-49E0-46A7-89C6-1868133736BE">
+  <rdf:Description rdf:about="http://www.wikidata.org/entity/statement/Q641676-1439BE45-49E0-46A7-89C6-1868133736BE">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Statement"/>
     <rdf:type rdf:resource="http://wikiba.se/ontology#BestRank"/>
     <wikibase:rank rdf:resource="http://wikiba.se/ontology#NormalRank"/>
@@ -1329,26 +1115,17 @@
     <schema:description xml:lang="nl">museum en onderzoekscentrum in Leiden</schema:description>
     <schema:description xml:lang="fr">musée et centre de recherche néerlandais</schema:description>
     <schema:description xml:lang="ru">музей в Голландии</schema:description>
-    <schema:description xml:lang="en">natural history museum and research center in the Leiden, The
-      Netherlands
-    </schema:description>
-    <schema:description xml:lang="uk">Природничий музей в місті Лейден, Нідерланди
-    </schema:description>
+    <schema:description xml:lang="en">natural history museum and research center in the Leiden, The Netherlands</schema:description>
+    <schema:description xml:lang="uk">Природничий музей в місті Лейден, Нідерланди</schema:description>
     <schema:description xml:lang="he">מוזיאון בהולנד</schema:description>
     <schema:description xml:lang="be-tarask">музэй</schema:description>
     <schema:description xml:lang="be">музей</schema:description>
-    <schema:description xml:lang="es">museo de historia natural y centro de investigación
-      neerlandés
-    </schema:description>
+    <schema:description xml:lang="es">museo de historia natural y centro de investigación neerlandés</schema:description>
     <schema:description xml:lang="id">museum nasional Belanda</schema:description>
-    <schema:description xml:lang="da">Naturhistorisk museum og forskningscenter i Nederlandene
-    </schema:description>
+    <schema:description xml:lang="da">Naturhistorisk museum og forskningscenter i Nederlandene</schema:description>
     <schema:description xml:lang="ja">生物学、地質学資料を保管展示する施設。4館併合で設立。</schema:description>
-    <schema:description xml:lang="it">museo di storia naturale e centro di ricerca neerlandese
-    </schema:description>
-    <schema:description xml:lang="de">niederländisches Naturkundemuseum und Forschungsinstitut in
-      Leiden
-    </schema:description>
+    <schema:description xml:lang="it">museo di storia naturale e centro di ricerca neerlandese</schema:description>
+    <schema:description xml:lang="de">niederländisches Naturkundemuseum und Forschungsinstitut in Leiden</schema:description>
     <skos:altLabel xml:lang="en">Naturalis Bio Center</skos:altLabel>
     <skos:altLabel xml:lang="en">NBC</skos:altLabel>
     <skos:altLabel xml:lang="en">RMNH</skos:altLabel>
@@ -1371,9 +1148,7 @@
     <rdfs:label xml:lang="en">Commons category</rdfs:label>
     <skos:prefLabel xml:lang="en">Commons category</skos:prefLabel>
     <schema:name xml:lang="en">Commons category</schema:name>
-    <schema:description xml:lang="en">name of the Wikimedia Commons category containing files
-      related to this item (without the prefix &quot;Category:&quot;)
-    </schema:description>
+    <schema:description xml:lang="en">name of the Wikimedia Commons category containing files related to this item (without the prefix &quot;Category:&quot;)</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#String"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P373"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P373"/>
@@ -1430,9 +1205,7 @@
     <rdfs:label xml:lang="en">country</rdfs:label>
     <skos:prefLabel xml:lang="en">country</skos:prefLabel>
     <schema:name xml:lang="en">country</schema:name>
-    <schema:description xml:lang="en">sovereign state of this item (not to be used for human
-      beings)
-    </schema:description>
+    <schema:description xml:lang="en">sovereign state of this item (not to be used for human beings)</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#WikibaseItem"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P17"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P17"/>
@@ -1482,19 +1255,14 @@
     <rdfs:label xml:lang="en">Leiden</rdfs:label>
     <skos:prefLabel xml:lang="en">Leiden</skos:prefLabel>
     <schema:name xml:lang="en">Leiden</schema:name>
-    <schema:description xml:lang="en">municipality in South Holland, Netherlands
-    </schema:description>
+    <schema:description xml:lang="en">municipality in South Holland, Netherlands</schema:description>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/P131">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Property"/>
     <rdfs:label xml:lang="en">located in the administrative territorial entity</rdfs:label>
     <skos:prefLabel xml:lang="en">located in the administrative territorial entity</skos:prefLabel>
     <schema:name xml:lang="en">located in the administrative territorial entity</schema:name>
-    <schema:description xml:lang="en">the item is located on the territory of the following
-      administrative entity. Use P276 for specifying locations that are non-administrative places
-      and for items about events. Use P1382 if the item falls only partially into the administrative
-      entity.
-    </schema:description>
+    <schema:description xml:lang="en">the item is located on the territory of the following administrative entity. Use P276 for specifying locations that are non-administrative places and for items about events. Use P1382 if the item falls only partially into the administrative entity.</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#WikibaseItem"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P131"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P131"/>
@@ -1551,9 +1319,7 @@
     <rdfs:label xml:lang="en">instance of</rdfs:label>
     <skos:prefLabel xml:lang="en">instance of</skos:prefLabel>
     <schema:name xml:lang="en">instance of</schema:name>
-    <schema:description xml:lang="en">that class of which this subject is a particular example and
-      member
-    </schema:description>
+    <schema:description xml:lang="en">that class of which this subject is a particular example and member</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#WikibaseItem"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P31"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P31"/>
@@ -1610,19 +1376,14 @@
     <rdfs:label xml:lang="en">government agency</rdfs:label>
     <skos:prefLabel xml:lang="en">government agency</skos:prefLabel>
     <schema:name xml:lang="en">government agency</schema:name>
-    <schema:description xml:lang="en">organization in the machinery of government responsible for
-      specific functions, excluding legislatures and courts
-    </schema:description>
+    <schema:description xml:lang="en">organization in the machinery of government responsible for specific functions, excluding legislatures and courts</schema:description>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/P18">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Property"/>
     <rdfs:label xml:lang="en">image</rdfs:label>
     <skos:prefLabel xml:lang="en">image</skos:prefLabel>
     <schema:name xml:lang="en">image</schema:name>
-    <schema:description xml:lang="en">image of relevant illustration of the subject; if available,
-      use more specific properties (sample: coat of arms image, locator map, flag image, signature
-      image, logo image, collage image)
-    </schema:description>
+    <schema:description xml:lang="en">image of relevant illustration of the subject; if available, use more specific properties (sample: coat of arms image, locator map, flag image, signature image, logo image, collage image)</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#CommonsMedia"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P18"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P18"/>
@@ -1672,9 +1433,7 @@
     <rdfs:label xml:lang="en">coordinate location</rdfs:label>
     <skos:prefLabel xml:lang="en">coordinate location</skos:prefLabel>
     <schema:name xml:lang="en">coordinate location</schema:name>
-    <schema:description xml:lang="en">geocoordinates of the subject. For Earth, please note that
-      only WGS84 coordinating system is supported at the moment
-    </schema:description>
+    <schema:description xml:lang="en">geocoordinates of the subject. For Earth, please note that only WGS84 coordinating system is supported at the moment</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#GlobeCoordinate"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P625"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P625"/>
@@ -1724,10 +1483,7 @@
     <rdfs:label xml:lang="en">Freebase ID</rdfs:label>
     <skos:prefLabel xml:lang="en">Freebase ID</skos:prefLabel>
     <schema:name xml:lang="en">Freebase ID</schema:name>
-    <schema:description xml:lang="en">identifier for a page in the Freebase database. Format: &quot;/m/0&quot;
-      followed by 2 to 7 characters. For those starting with &quot;/g/&quot;, use Google Knowledge
-      Graph identifier (P2671)
-    </schema:description>
+    <schema:description xml:lang="en">identifier for a page in the Freebase database. Format: &quot;/m/0&quot; followed by 2 to 7 characters. For those starting with &quot;/g/&quot;, use Google Knowledge Graph identifier (P2671)</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P646"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P646"/>
@@ -1738,14 +1494,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P646"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P646"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P646"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P646"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P646"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P646"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P646"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P646"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P646"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P646"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P646"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P646">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -1797,10 +1549,7 @@
     <rdfs:label xml:lang="en">GND ID</rdfs:label>
     <skos:prefLabel xml:lang="en">GND ID</skos:prefLabel>
     <schema:name xml:lang="en">GND ID</schema:name>
-    <schema:description xml:lang="en">identifier from an international authority file of names,
-      subjects, and organizations (please don&#039;t use type n = name, disambiguation) - Deutsche
-      Nationalbibliothek
-    </schema:description>
+    <schema:description xml:lang="en">identifier from an international authority file of names, subjects, and organizations (please don&#039;t use type n = name, disambiguation) - Deutsche Nationalbibliothek</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P227"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P227"/>
@@ -1811,14 +1560,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P227"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P227"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P227"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P227"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P227"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P227"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P227"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P227"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P227"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P227"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P227"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P227">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -1877,8 +1622,7 @@
     <rdfs:label xml:lang="en">chairperson</rdfs:label>
     <skos:prefLabel xml:lang="en">chairperson</skos:prefLabel>
     <schema:name xml:lang="en">chairperson</schema:name>
-    <schema:description xml:lang="en">presiding member of an organization, group or body
-    </schema:description>
+    <schema:description xml:lang="en">presiding member of an organization, group or body</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#WikibaseItem"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P488"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P488"/>
@@ -1928,10 +1672,7 @@
     <rdfs:label xml:lang="en">official website</rdfs:label>
     <skos:prefLabel xml:lang="en">official website</skos:prefLabel>
     <schema:name xml:lang="en">official website</schema:name>
-    <schema:description xml:lang="en">URL of the official homepage of an item (current or former)
-      [if the homepage changes, add an additional statement with preferred rank. Do not remove the
-      former URL]
-    </schema:description>
+    <schema:description xml:lang="en">URL of the official homepage of an item (current or former) [if the homepage changes, add an additional statement with preferred rank. Do not remove the former URL]</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#Url"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P856"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P856"/>
@@ -1981,8 +1722,7 @@
     <rdfs:label xml:lang="en">visitors per year</rdfs:label>
     <skos:prefLabel xml:lang="en">visitors per year</skos:prefLabel>
     <schema:name xml:lang="en">visitors per year</schema:name>
-    <schema:description xml:lang="en">number of people visiting a location or an event each year
-    </schema:description>
+    <schema:description xml:lang="en">number of people visiting a location or an event each year</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#Quantity"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P1174"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P1174"/>
@@ -1993,14 +1733,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P1174"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P1174"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P1174"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P1174"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P1174"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P1174"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P1174"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P1174"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P1174"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P1174"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P1174"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P1174">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -2052,9 +1788,7 @@
     <rdfs:label xml:lang="en">VIAF ID</rdfs:label>
     <skos:prefLabel xml:lang="en">VIAF ID</skos:prefLabel>
     <schema:name xml:lang="en">VIAF ID</schema:name>
-    <schema:description xml:lang="en">identifier for the Virtual International Authority File
-      database [format: up to 22 digits]
-    </schema:description>
+    <schema:description xml:lang="en">identifier for the Virtual International Authority File database [format: up to 22 digits]</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P214"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P214"/>
@@ -2065,14 +1799,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P214"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P214"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P214"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P214"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P214"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P214"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P214"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P214"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P214"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P214"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P214"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P214">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -2124,11 +1854,7 @@
     <rdfs:label xml:lang="en">Library of Congress authority ID</rdfs:label>
     <skos:prefLabel xml:lang="en">Library of Congress authority ID</skos:prefLabel>
     <schema:name xml:lang="en">Library of Congress authority ID</schema:name>
-    <schema:description xml:lang="en">Library of Congress name authority (persons, families,
-      corporate bodies, events, places, works and expressions) and subject authority identifier
-      [Format: 1-2 specific letters followed by 8-10 digits (see regex). For manifestations, use
-      P1144]
-    </schema:description>
+    <schema:description xml:lang="en">Library of Congress name authority (persons, families, corporate bodies, events, places, works and expressions) and subject authority identifier [Format: 1-2 specific letters followed by 8-10 digits (see regex). For manifestations, use P1144]</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P244"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P244"/>
@@ -2139,14 +1865,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P244"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P244"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P244"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P244"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P244"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P244"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P244"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P244"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P244"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P244"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P244"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P244">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -2198,9 +1920,7 @@
     <rdfs:label xml:lang="en">CTBUH Skyscraper Center building ID</rdfs:label>
     <skos:prefLabel xml:lang="en">CTBUH Skyscraper Center building ID</skos:prefLabel>
     <schema:name xml:lang="en">CTBUH Skyscraper Center building ID</schema:name>
-    <schema:description xml:lang="en">identifier for a building as used on the CTBUH&#039;s
-      www.skyscrapercenter.com
-    </schema:description>
+    <schema:description xml:lang="en">identifier for a building as used on the CTBUH&#039;s www.skyscrapercenter.com</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P1305"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P1305"/>
@@ -2211,14 +1931,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P1305"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P1305"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P1305"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P1305"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P1305"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P1305"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P1305"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P1305"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P1305"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P1305"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P1305"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P1305">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -2270,9 +1986,7 @@
     <rdfs:label xml:lang="en">IdRef ID</rdfs:label>
     <skos:prefLabel xml:lang="en">IdRef ID</skos:prefLabel>
     <schema:name xml:lang="en">IdRef ID</schema:name>
-    <schema:description xml:lang="en">identifier for authority control in the French collaborative
-      library catalog (see also P1025). Format: 8 digits followed by a digit or &quot;X&quot;
-    </schema:description>
+    <schema:description xml:lang="en">identifier for authority control in the French collaborative library catalog (see also P1025). Format: 8 digits followed by a digit or &quot;X&quot;</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P269"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P269"/>
@@ -2283,14 +1997,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P269"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P269"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P269"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P269"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P269"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P269"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P269"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P269"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P269"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P269"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P269"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P269">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -2349,10 +2059,7 @@
     <rdfs:label xml:lang="en">replaces</rdfs:label>
     <skos:prefLabel xml:lang="en">replaces</skos:prefLabel>
     <schema:name xml:lang="en">replaces</schema:name>
-    <schema:description xml:lang="en">person, state or item replaced. Use &quot;structure replaces&quot;
-      (P1398) for structures. Use &quot;follows&quot; (P155) if the previous item was not replaced
-      or predecessor and successor are identical
-    </schema:description>
+    <schema:description xml:lang="en">person, state or item replaced. Use &quot;structure replaces&quot; (P1398) for structures. Use &quot;follows&quot; (P155) if the previous item was not replaced or predecessor and successor are identical</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#WikibaseItem"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P1365"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P1365"/>
@@ -2409,8 +2116,7 @@
     <rdfs:label xml:lang="en">Rijksmuseum van Natuurlijke Historie</rdfs:label>
     <skos:prefLabel xml:lang="en">Rijksmuseum van Natuurlijke Historie</skos:prefLabel>
     <schema:name xml:lang="en">Rijksmuseum van Natuurlijke Historie</schema:name>
-    <schema:description xml:lang="en">National Museum of Natural History in Leiden, Netherlands
-    </schema:description>
+    <schema:description xml:lang="en">National Museum of Natural History in Leiden, Netherlands</schema:description>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q7333956">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Item"/>
@@ -2423,9 +2129,7 @@
     <rdfs:label xml:lang="en">inception</rdfs:label>
     <skos:prefLabel xml:lang="en">inception</skos:prefLabel>
     <schema:name xml:lang="en">inception</schema:name>
-    <schema:description xml:lang="en">date or point in time when the subject came into existence as
-      defined
-    </schema:description>
+    <schema:description xml:lang="en">date or point in time when the subject came into existence as defined</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#Time"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P571"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P571"/>
@@ -2475,9 +2179,7 @@
     <rdfs:label xml:lang="en">Twitter username</rdfs:label>
     <skos:prefLabel xml:lang="en">Twitter username</skos:prefLabel>
     <schema:name xml:lang="en">Twitter username</schema:name>
-    <schema:description xml:lang="en">this item&#039;s username on Twitter; do not include the “@”
-      symbol
-    </schema:description>
+    <schema:description xml:lang="en">this item&#039;s username on Twitter; do not include the “@” symbol</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P2002"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P2002"/>
@@ -2488,14 +2190,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P2002"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P2002"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P2002"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P2002"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P2002"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P2002"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P2002"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P2002"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P2002"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P2002"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P2002"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P2002">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -2547,9 +2245,7 @@
     <rdfs:label xml:lang="en">ISNI</rdfs:label>
     <skos:prefLabel xml:lang="en">ISNI</skos:prefLabel>
     <schema:name xml:lang="en">ISNI</schema:name>
-    <schema:description xml:lang="en">International Standard Name Identifier for an identity.
-      Format: 4 blocks of 4 digits separated by a space, first block is 0000
-    </schema:description>
+    <schema:description xml:lang="en">International Standard Name Identifier for an identity. Format: 4 blocks of 4 digits separated by a space, first block is 0000</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P213"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P213"/>
@@ -2560,14 +2256,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P213"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P213"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P213"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P213"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P213"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P213"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P213"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P213"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P213"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P213"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P213"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P213">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -2619,9 +2311,7 @@
     <rdfs:label xml:lang="en">Ringgold ID</rdfs:label>
     <skos:prefLabel xml:lang="en">Ringgold ID</skos:prefLabel>
     <schema:name xml:lang="en">Ringgold ID</schema:name>
-    <schema:description xml:lang="en">identifier for organisations in the publishing industry supply
-      chain
-    </schema:description>
+    <schema:description xml:lang="en">identifier for organisations in the publishing industry supply chain</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P3500"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P3500"/>
@@ -2632,14 +2322,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P3500"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P3500"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P3500"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P3500"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P3500"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P3500"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P3500"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P3500"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P3500"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P3500"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P3500"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P3500">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -2691,9 +2377,7 @@
     <rdfs:label xml:lang="en">EU Transparency Register ID</rdfs:label>
     <skos:prefLabel xml:lang="en">EU Transparency Register ID</skos:prefLabel>
     <schema:name xml:lang="en">EU Transparency Register ID</schema:name>
-    <schema:description xml:lang="en">identity code for an organisation, in the transparency
-      register of the European Union
-    </schema:description>
+    <schema:description xml:lang="en">identity code for an organisation, in the transparency register of the European Union</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P2657"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P2657"/>
@@ -2704,14 +2388,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P2657"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P2657"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P2657"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P2657"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P2657"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P2657"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P2657"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P2657"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P2657"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P2657"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P2657"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P2657">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -2813,8 +2493,7 @@
     <rdfs:label xml:lang="en">Actorenregister ID</rdfs:label>
     <skos:prefLabel xml:lang="en">Actorenregister ID</skos:prefLabel>
     <schema:name xml:lang="en">Actorenregister ID</schema:name>
-    <schema:description xml:lang="en">unique identifier in the Dutch Actorenregister database
-    </schema:description>
+    <schema:description xml:lang="en">unique identifier in the Dutch Actorenregister database</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P3273"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P3273"/>
@@ -2825,14 +2504,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P3273"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P3273"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P3273"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P3273"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P3273"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P3273"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P3273"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P3273"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P3273"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P3273"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P3273"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P3273">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -2884,9 +2559,7 @@
     <rdfs:label xml:lang="en">NLA Trove ID</rdfs:label>
     <skos:prefLabel xml:lang="en">NLA Trove ID</skos:prefLabel>
     <schema:name xml:lang="en">NLA Trove ID</schema:name>
-    <schema:description xml:lang="en">identifier for people per National Library of Australia (see
-      also P409 for the older Libraries Australia identifier). Format: 5 to 7 digits.
-    </schema:description>
+    <schema:description xml:lang="en">identifier for people per National Library of Australia (see also P409 for the older Libraries Australia identifier). Format: 5 to 7 digits.</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P1315"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P1315"/>
@@ -2897,14 +2570,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P1315"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P1315"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P1315"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P1315"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P1315"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P1315"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P1315"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P1315"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P1315"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P1315"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P1315"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P1315">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -2967,14 +2636,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P1662"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P1662"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P1662"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P1662"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P1662"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P1662"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P1662"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P1662"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P1662"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P1662"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P1662"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P1662">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -3026,9 +2691,7 @@
     <rdfs:label xml:lang="en">Google Arts &amp; Culture partner ID</rdfs:label>
     <skos:prefLabel xml:lang="en">Google Arts &amp; Culture partner ID</skos:prefLabel>
     <schema:name xml:lang="en">Google Arts &amp; Culture partner ID</schema:name>
-    <schema:description xml:lang="en">identifier for a museum or other partner on the Google Arts
-      &amp; Culture website
-    </schema:description>
+    <schema:description xml:lang="en">identifier for a museum or other partner on the Google Arts &amp; Culture website</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P4702"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P4702"/>
@@ -3039,14 +2702,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P4702"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P4702"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P4702"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P4702"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P4702"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P4702"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P4702"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P4702"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P4702"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P4702"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P4702"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P4702">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -3098,9 +2757,7 @@
     <rdfs:label xml:lang="en">Commons Institution page</rdfs:label>
     <skos:prefLabel xml:lang="en">Commons Institution page</skos:prefLabel>
     <schema:name xml:lang="en">Commons Institution page</schema:name>
-    <schema:description xml:lang="en">name of the institutions&#039;s page on Wikimedia Commons
-      (without the prefix &quot;Institution&quot;)
-    </schema:description>
+    <schema:description xml:lang="en">name of the institutions&#039;s page on Wikimedia Commons (without the prefix &quot;Institution&quot;)</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#String"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P1612"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P1612"/>
@@ -3150,9 +2807,7 @@
     <rdfs:label xml:lang="en">GRID ID</rdfs:label>
     <skos:prefLabel xml:lang="en">GRID ID</skos:prefLabel>
     <schema:name xml:lang="en">GRID ID</schema:name>
-    <schema:description xml:lang="en">institutional identifier from the GRID.ac global research
-      identifier database
-    </schema:description>
+    <schema:description xml:lang="en">institutional identifier from the GRID.ac global research identifier database</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P2427"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P2427"/>
@@ -3163,14 +2818,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P2427"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P2427"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P2427"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P2427"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P2427"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P2427"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P2427"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P2427"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P2427"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P2427"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P2427"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P2427">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -3222,9 +2873,7 @@
     <rdfs:label xml:lang="en">short name</rdfs:label>
     <skos:prefLabel xml:lang="en">short name</skos:prefLabel>
     <schema:name xml:lang="en">short name</schema:name>
-    <schema:description xml:lang="en">short name of a place, organisation, person, Wikidata
-      property, etc.
-    </schema:description>
+    <schema:description xml:lang="en">short name of a place, organisation, person, Wikidata property, etc.</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#Monolingualtext"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P1813"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P1813"/>
@@ -3274,9 +2923,7 @@
     <rdfs:label xml:lang="en">date of official opening</rdfs:label>
     <skos:prefLabel xml:lang="en">date of official opening</skos:prefLabel>
     <schema:name xml:lang="en">date of official opening</schema:name>
-    <schema:description xml:lang="en">date or point in time an event, museum, theater etc.
-      officially opened
-    </schema:description>
+    <schema:description xml:lang="en">date or point in time an event, museum, theater etc. officially opened</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#Time"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P1619"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P1619"/>
@@ -3326,8 +2973,7 @@
     <rdfs:label xml:lang="en">Museumkaart</rdfs:label>
     <skos:prefLabel xml:lang="en">Museumkaart</skos:prefLabel>
     <schema:name xml:lang="en">Museumkaart</schema:name>
-    <schema:description xml:lang="en">pass that gives free entrance to many Dutch museums
-    </schema:description>
+    <schema:description xml:lang="en">pass that gives free entrance to many Dutch museums</schema:description>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/P2851">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Property"/>
@@ -3384,18 +3030,14 @@
     <rdfs:label xml:lang="en">ICOM membership card</rdfs:label>
     <skos:prefLabel xml:lang="en">ICOM membership card</skos:prefLabel>
     <schema:name xml:lang="en">ICOM membership card</schema:name>
-    <schema:description xml:lang="en">card distributed to members of the ICOM that provides free or
-      reduced entry to museums all over the world
-    </schema:description>
+    <schema:description xml:lang="en">card distributed to members of the ICOM that provides free or reduced entry to museums all over the world</schema:description>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/P281">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Property"/>
     <rdfs:label xml:lang="en">postal code</rdfs:label>
     <skos:prefLabel xml:lang="en">postal code</skos:prefLabel>
     <schema:name xml:lang="en">postal code</schema:name>
-    <schema:description xml:lang="en">identifier assigned by postal authorities for the subject area
-      or building
-    </schema:description>
+    <schema:description xml:lang="en">identifier assigned by postal authorities for the subject area or building</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#String"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P281"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P281"/>
@@ -3445,9 +3087,7 @@
     <rdfs:label xml:lang="en">phone number</rdfs:label>
     <skos:prefLabel xml:lang="en">phone number</skos:prefLabel>
     <schema:name xml:lang="en">phone number</schema:name>
-    <schema:description xml:lang="en">telephone number in standard format (RFC3966), without &#039;tel:&#039;
-      prefix
-    </schema:description>
+    <schema:description xml:lang="en">telephone number in standard format (RFC3966), without &#039;tel:&#039; prefix</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#String"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P1329"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P1329"/>
@@ -3554,10 +3194,7 @@
     <rdfs:label xml:lang="en">subsidiary</rdfs:label>
     <skos:prefLabel xml:lang="en">subsidiary</skos:prefLabel>
     <schema:name xml:lang="en">subsidiary</schema:name>
-    <schema:description xml:lang="en">subsidiary of a company or organization; generally a fully
-      owned separate corporation. Compare with &quot;business division&quot; (P199). Opposite of
-      parent organization (P749).
-    </schema:description>
+    <schema:description xml:lang="en">subsidiary of a company or organization; generally a fully owned separate corporation. Compare with &quot;business division&quot; (P199). Opposite of parent organization (P749).</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#WikibaseItem"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P355"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P355"/>
@@ -3664,9 +3301,7 @@
     <rdfs:label xml:lang="en">Sotheby&#039;s Museum Network ID</rdfs:label>
     <skos:prefLabel xml:lang="en">Sotheby&#039;s Museum Network ID</skos:prefLabel>
     <schema:name xml:lang="en">Sotheby&#039;s Museum Network ID</schema:name>
-    <schema:description xml:lang="en">identifier for a museum on the Sotheby&#039;s Museum Network
-      website
-    </schema:description>
+    <schema:description xml:lang="en">identifier for a museum on the Sotheby&#039;s Museum Network website</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P6155"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P6155"/>
@@ -3677,14 +3312,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P6155"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P6155"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P6155"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P6155"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P6155"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P6155"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P6155"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P6155"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P6155"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P6155"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P6155"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P6155">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -3736,9 +3367,7 @@
     <rdfs:label xml:lang="en">Biodiversity Repository ID</rdfs:label>
     <skos:prefLabel xml:lang="en">Biodiversity Repository ID</skos:prefLabel>
     <schema:name xml:lang="en">Biodiversity Repository ID</schema:name>
-    <schema:description xml:lang="en">identifier of a repository, in the Biodiversity Repository
-      database
-    </schema:description>
+    <schema:description xml:lang="en">identifier of a repository, in the Biodiversity Repository database</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P4090"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P4090"/>
@@ -3749,14 +3378,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P4090"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P4090"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P4090"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P4090"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P4090"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P4090"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P4090"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P4090"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P4090"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P4090"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P4090"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P4090">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -3808,8 +3433,7 @@
     <rdfs:label xml:lang="en">ROR ID</rdfs:label>
     <skos:prefLabel xml:lang="en">ROR ID</skos:prefLabel>
     <schema:name xml:lang="en">ROR ID</schema:name>
-    <schema:description xml:lang="en">identifier for the Research Organization Registry
-    </schema:description>
+    <schema:description xml:lang="en">identifier for the Research Organization Registry</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P6782"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P6782"/>
@@ -3820,14 +3444,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P6782"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P6782"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P6782"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P6782"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P6782"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P6782"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P6782"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P6782"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P6782"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P6782"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P6782"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P6782">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -3886,9 +3506,7 @@
     <rdfs:label xml:lang="en">architect</rdfs:label>
     <skos:prefLabel xml:lang="en">architect</skos:prefLabel>
     <schema:name xml:lang="en">architect</schema:name>
-    <schema:description xml:lang="en">person or architectural firm responsible for designing this
-      building
-    </schema:description>
+    <schema:description xml:lang="en">person or architectural firm responsible for designing this building</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#WikibaseItem"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P84"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P84"/>
@@ -3945,9 +3563,7 @@
     <rdfs:label xml:lang="en">Survey of GLAM open access policy and practice</rdfs:label>
     <skos:prefLabel xml:lang="en">Survey of GLAM open access policy and practice</skos:prefLabel>
     <schema:name xml:lang="en">Survey of GLAM open access policy and practice</schema:name>
-    <schema:description xml:lang="en">data set collected by Dr. Andrea Wallace and Douglas
-      McCarthy
-    </schema:description>
+    <schema:description xml:lang="en">data set collected by Dr. Andrea Wallace and Douglas McCarthy</schema:description>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/P1343">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Property"/>
@@ -4004,9 +3620,7 @@
     <rdfs:label xml:lang="en">Microsoft Academic ID</rdfs:label>
     <skos:prefLabel xml:lang="en">Microsoft Academic ID</skos:prefLabel>
     <schema:name xml:lang="en">Microsoft Academic ID</schema:name>
-    <schema:description xml:lang="en">identifier for an object or topic in the Microsoft Academic
-      Graph
-    </schema:description>
+    <schema:description xml:lang="en">identifier for an object or topic in the Microsoft Academic Graph</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P6366"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P6366"/>
@@ -4017,14 +3631,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P6366"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P6366"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P6366"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P6366"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P6366"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P6366"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P6366"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P6366"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P6366"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P6366"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P6366"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P6366">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -4083,10 +3693,7 @@
     <rdfs:label xml:lang="en">member of</rdfs:label>
     <skos:prefLabel xml:lang="en">member of</skos:prefLabel>
     <schema:name xml:lang="en">member of</schema:name>
-    <schema:description xml:lang="en">organization, club or musical group to which the subject
-      belongs. Do not use for membership in ethnic or social groups, nor for holding a political
-      position, such as a member of parliament (use P39 for that).
-    </schema:description>
+    <schema:description xml:lang="en">organization, club or musical group to which the subject belongs. Do not use for membership in ethnic or social groups, nor for holding a political position, such as a member of parliament (use P39 for that).</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#WikibaseItem"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P463"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P463"/>
@@ -4136,9 +3743,7 @@
     <rdfs:label xml:lang="en">Biodiversity Information Standards</rdfs:label>
     <skos:prefLabel xml:lang="en">Biodiversity Information Standards</skos:prefLabel>
     <schema:name xml:lang="en">Biodiversity Information Standards</schema:name>
-    <schema:description xml:lang="en">a scientific and educational association for standards
-      development
-    </schema:description>
+    <schema:description xml:lang="en">a scientific and educational association for standards development</schema:description>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q1991604">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Item"/>
@@ -4152,9 +3757,7 @@
     <rdfs:label xml:lang="en">BHL creator ID</rdfs:label>
     <skos:prefLabel xml:lang="en">BHL creator ID</skos:prefLabel>
     <schema:name xml:lang="en">BHL creator ID</schema:name>
-    <schema:description xml:lang="en">identifier for an author (&quot;creator&quot;) in the
-      Biodiversity Heritage Library database
-    </schema:description>
+    <schema:description xml:lang="en">identifier for an author (&quot;creator&quot;) in the Biodiversity Heritage Library database</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P4081"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P4081"/>
@@ -4165,14 +3768,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P4081"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P4081"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P4081"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P4081"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P4081"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P4081"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P4081"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P4081"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P4081"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P4081"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P4081"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P4081">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -4224,8 +3823,7 @@
     <rdfs:label xml:lang="en">WorldCat Identities ID</rdfs:label>
     <skos:prefLabel xml:lang="en">WorldCat Identities ID</skos:prefLabel>
     <schema:name xml:lang="en">WorldCat Identities ID</schema:name>
-    <schema:description xml:lang="en">entity on WorldCat. Use P243 OCLC control number for books
-    </schema:description>
+    <schema:description xml:lang="en">entity on WorldCat. Use P243 OCLC control number for books</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P7859"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P7859"/>
@@ -4236,14 +3834,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P7859"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P7859"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P7859"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P7859"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P7859"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P7859"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P7859"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P7859"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P7859"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P7859"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P7859"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P7859">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -4295,9 +3889,7 @@
     <rdfs:label xml:lang="en">Facebook ID</rdfs:label>
     <skos:prefLabel xml:lang="en">Facebook ID</skos:prefLabel>
     <schema:name xml:lang="en">Facebook ID</schema:name>
-    <schema:description xml:lang="en">identifier for an official (preferably) Facebook person,
-      product or organization page (everything that follows URL part &#039;https://www.facebook.com/&#039;)
-    </schema:description>
+    <schema:description xml:lang="en">identifier for an official (preferably) Facebook person, product or organization page (everything that follows URL part &#039;https://www.facebook.com/&#039;)</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P2013"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P2013"/>
@@ -4308,14 +3900,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P2013"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P2013"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P2013"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P2013"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P2013"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P2013"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P2013"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P2013"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P2013"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P2013"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P2013"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P2013">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -4378,14 +3966,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P2003"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P2003"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P2003"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P2003"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P2003"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P2003"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P2003"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P2003"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P2003"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P2003"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P2003"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P2003">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -4437,9 +4021,7 @@
     <rdfs:label xml:lang="en">YouTube channel ID</rdfs:label>
     <skos:prefLabel xml:lang="en">YouTube channel ID</skos:prefLabel>
     <schema:name xml:lang="en">YouTube channel ID</schema:name>
-    <schema:description xml:lang="en">ID of the YouTube channel of a person or organisation (not to
-      be confused with the name of the channel) The ID can also be used for music.youtube.com IDs.
-    </schema:description>
+    <schema:description xml:lang="en">ID of the YouTube channel of a person or organisation (not to be confused with the name of the channel) The ID can also be used for music.youtube.com IDs.</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P2397"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P2397"/>
@@ -4450,14 +4032,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P2397"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P2397"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P2397"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P2397"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P2397"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P2397"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P2397"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P2397"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P2397"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P2397"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P2397"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P2397">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -4559,8 +4137,7 @@
     <rdfs:label xml:lang="en">native label</rdfs:label>
     <skos:prefLabel xml:lang="en">native label</skos:prefLabel>
     <schema:name xml:lang="en">native label</schema:name>
-    <schema:description xml:lang="en">label for item in its official or original language
-    </schema:description>
+    <schema:description xml:lang="en">label for item in its official or original language</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#Monolingualtext"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P1705"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P1705"/>
@@ -4608,8 +4185,7 @@
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q97584168">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Item"/>
     <rdfs:label xml:lang="en">Category:Media donated by Naturalis Biodiversity Center</rdfs:label>
-    <skos:prefLabel xml:lang="en">Category:Media donated by Naturalis Biodiversity Center
-    </skos:prefLabel>
+    <skos:prefLabel xml:lang="en">Category:Media donated by Naturalis Biodiversity Center</skos:prefLabel>
     <schema:name xml:lang="en">Category:Media donated by Naturalis Biodiversity Center</schema:name>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/P8464">
@@ -4617,9 +4193,7 @@
     <rdfs:label xml:lang="en">content partnership category</rdfs:label>
     <skos:prefLabel xml:lang="en">content partnership category</skos:prefLabel>
     <schema:name xml:lang="en">content partnership category</schema:name>
-    <schema:description xml:lang="en">Wikimedia Commons category for media files contributed by this
-      institution
-    </schema:description>
+    <schema:description xml:lang="en">Wikimedia Commons category for media files contributed by this institution</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#WikibaseItem"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P8464"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P8464"/>
@@ -4669,10 +4243,7 @@
     <rdfs:label xml:lang="en">social media followers</rdfs:label>
     <skos:prefLabel xml:lang="en">social media followers</skos:prefLabel>
     <schema:name xml:lang="en">social media followers</schema:name>
-    <schema:description xml:lang="en">number of subscribers on a particular social media website
-      (use as main statement only; see P3744 instead for qualifier). Qualify with &quot;point in
-      time&quot; and property for account. For Twitter, use numeric id.
-    </schema:description>
+    <schema:description xml:lang="en">number of subscribers on a particular social media website (use as main statement only; see P3744 instead for qualifier). Qualify with &quot;point in time&quot; and property for account. For Twitter, use numeric id.</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#Quantity"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P8687"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P8687"/>
@@ -4683,14 +4254,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P8687"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P8687"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P8687"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P8687"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P8687"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P8687"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P8687"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P8687"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P8687"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P8687"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P8687"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P8687">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -4742,8 +4309,7 @@
     <rdfs:label xml:lang="en">Name Assigning Authority Number</rdfs:label>
     <skos:prefLabel xml:lang="en">Name Assigning Authority Number</skos:prefLabel>
     <schema:name xml:lang="en">Name Assigning Authority Number</schema:name>
-    <schema:description xml:lang="en">identifier in the Archival Resource Key registry
-    </schema:description>
+    <schema:description xml:lang="en">identifier in the Archival Resource Key registry</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P1870"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P1870"/>
@@ -4754,14 +4320,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P1870"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P1870"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P1870"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P1870"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P1870"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P1870"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P1870"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P1870"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P1870"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P1870"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P1870"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P1870">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -4813,8 +4375,7 @@
     <rdfs:label xml:lang="en">BaGLAMa GID</rdfs:label>
     <skos:prefLabel xml:lang="en">BaGLAMa GID</skos:prefLabel>
     <schema:name xml:lang="en">BaGLAMa GID</schema:name>
-    <schema:description xml:lang="en">unique identifier of category in the BaGLAMa tool
-    </schema:description>
+    <schema:description xml:lang="en">unique identifier of category in the BaGLAMa tool</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P8272"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P8272"/>
@@ -4825,14 +4386,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P8272"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P8272"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P8272"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P8272"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P8272"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P8272"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P8272"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P8272"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P8272"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P8272"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P8272"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P8272">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -4884,8 +4441,7 @@
     <rdfs:label xml:lang="en">Publons publisher ID</rdfs:label>
     <skos:prefLabel xml:lang="en">Publons publisher ID</skos:prefLabel>
     <schema:name xml:lang="en">Publons publisher ID</schema:name>
-    <schema:description xml:lang="en">identifier for publishers on the Publons website
-    </schema:description>
+    <schema:description xml:lang="en">identifier for publishers on the Publons website</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P7403"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P7403"/>
@@ -4896,14 +4452,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P7403"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P7403"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P7403"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P7403"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P7403"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P7403"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P7403"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P7403"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P7403"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P7403"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P7403"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P7403">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -4966,14 +4518,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P6698"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P6698"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P6698"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P6698"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P6698"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P6698"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P6698"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P6698"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P6698"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P6698"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P6698"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P6698">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -5025,8 +4573,7 @@
     <rdfs:label xml:lang="en">terms of service URL</rdfs:label>
     <skos:prefLabel xml:lang="en">terms of service URL</skos:prefLabel>
     <schema:name xml:lang="en">terms of service URL</schema:name>
-    <schema:description xml:lang="en">URL linking to terms of service of the subject
-    </schema:description>
+    <schema:description xml:lang="en">URL linking to terms of service of the subject</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#Url"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P7014"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P7014"/>
@@ -5083,9 +4630,7 @@
     <rdfs:label xml:lang="en">award received</rdfs:label>
     <skos:prefLabel xml:lang="en">award received</skos:prefLabel>
     <schema:name xml:lang="en">award received</schema:name>
-    <schema:description xml:lang="en">award or recognition received by a person, organisation or
-      creative work
-    </schema:description>
+    <schema:description xml:lang="en">award or recognition received by a person, organisation or creative work</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#WikibaseItem"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P166"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P166"/>
@@ -5135,9 +4680,7 @@
     <rdfs:label xml:lang="en">Architectuurgids building ID</rdfs:label>
     <skos:prefLabel xml:lang="en">Architectuurgids building ID</skos:prefLabel>
     <schema:name xml:lang="en">Architectuurgids building ID</schema:name>
-    <schema:description xml:lang="en">unique identifier for a building in the Dutch
-      architectuurgids.nl database
-    </schema:description>
+    <schema:description xml:lang="en">unique identifier for a building in the Dutch architectuurgids.nl database</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P3059"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P3059"/>
@@ -5148,14 +4691,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P3059"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P3059"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P3059"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P3059"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P3059"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P3059"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P3059"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P3059"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P3059"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P3059"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P3059"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P3059">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -5207,17 +4746,14 @@
     <rdfs:label xml:lang="en">Dutch Wikipedia</rdfs:label>
     <skos:prefLabel xml:lang="en">Dutch Wikipedia</skos:prefLabel>
     <schema:name xml:lang="en">Dutch Wikipedia</schema:name>
-    <schema:description xml:lang="en">Dutch language edition of Wikipedia, the free encyclopedia
-    </schema:description>
+    <schema:description xml:lang="en">Dutch language edition of Wikipedia, the free encyclopedia</schema:description>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/P143">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Property"/>
     <rdfs:label xml:lang="en">imported from Wikimedia project</rdfs:label>
     <skos:prefLabel xml:lang="en">imported from Wikimedia project</skos:prefLabel>
     <schema:name xml:lang="en">imported from Wikimedia project</schema:name>
-    <schema:description xml:lang="en">source of this claim&#039;s value; used in references section
-      by bots or humans importing data from Wikimedia projects
-    </schema:description>
+    <schema:description xml:lang="en">source of this claim&#039;s value; used in references section by bots or humans importing data from Wikimedia projects</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#WikibaseItem"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P143"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P143"/>
@@ -5274,17 +4810,14 @@
     <rdfs:label xml:lang="en">Freebase Data Dumps</rdfs:label>
     <skos:prefLabel xml:lang="en">Freebase Data Dumps</skos:prefLabel>
     <schema:name xml:lang="en">Freebase Data Dumps</schema:name>
-    <schema:description xml:lang="en">dumps of the public part of Google&#039;s Knowledge Graph
-    </schema:description>
+    <schema:description xml:lang="en">dumps of the public part of Google&#039;s Knowledge Graph</schema:description>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/P248">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Property"/>
     <rdfs:label xml:lang="en">stated in</rdfs:label>
     <skos:prefLabel xml:lang="en">stated in</skos:prefLabel>
     <schema:name xml:lang="en">stated in</schema:name>
-    <schema:description xml:lang="en">to be used in the references field to refer to the information
-      document or database in which a claim is made; for qualifiers use P805
-    </schema:description>
+    <schema:description xml:lang="en">to be used in the references field to refer to the information document or database in which a claim is made; for qualifiers use P805</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#WikibaseItem"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P248"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P248"/>
@@ -5334,9 +4867,7 @@
     <rdfs:label xml:lang="en">publication date</rdfs:label>
     <skos:prefLabel xml:lang="en">publication date</skos:prefLabel>
     <schema:name xml:lang="en">publication date</schema:name>
-    <schema:description xml:lang="en">date or point in time when a work was first published or
-      released
-    </schema:description>
+    <schema:description xml:lang="en">date or point in time when a work was first published or released</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#Time"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P577"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P577"/>
@@ -5393,17 +4924,14 @@
     <rdfs:label xml:lang="en">Japan Search</rdfs:label>
     <skos:prefLabel xml:lang="en">Japan Search</skos:prefLabel>
     <schema:name xml:lang="en">Japan Search</schema:name>
-    <schema:description xml:lang="en">portal to digital archives of Japanese culture and history
-    </schema:description>
+    <schema:description xml:lang="en">portal to digital archives of Japanese culture and history</schema:description>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/P813">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Property"/>
     <rdfs:label xml:lang="en">retrieved</rdfs:label>
     <skos:prefLabel xml:lang="en">retrieved</skos:prefLabel>
     <schema:name xml:lang="en">retrieved</schema:name>
-    <schema:description xml:lang="en">date or point in time that information was retrieved from a
-      database or website (for use in online sources)
-    </schema:description>
+    <schema:description xml:lang="en">date or point in time that information was retrieved from a database or website (for use in online sources)</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#Time"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P813"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P813"/>
@@ -5453,18 +4981,14 @@
     <rdfs:label xml:lang="en">Virtual International Authority File</rdfs:label>
     <skos:prefLabel xml:lang="en">Virtual International Authority File</skos:prefLabel>
     <schema:name xml:lang="en">Virtual International Authority File</schema:name>
-    <schema:description xml:lang="en">OCLC dataset and service that virtually combines multiple name
-      authority files into a single name authority service
-    </schema:description>
+    <schema:description xml:lang="en">OCLC dataset and service that virtually combines multiple name authority files into a single name authority service</schema:description>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/P3744">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Property"/>
     <rdfs:label xml:lang="en">number of subscribers</rdfs:label>
     <skos:prefLabel xml:lang="en">number of subscribers</skos:prefLabel>
     <schema:name xml:lang="en">number of subscribers</schema:name>
-    <schema:description xml:lang="en">number of subscribers for subscription based companies, e.g.
-      telecommunication companies, newspapers, pay-TV channels, software, etc.
-    </schema:description>
+    <schema:description xml:lang="en">number of subscribers for subscription based companies, e.g. telecommunication companies, newspapers, pay-TV channels, software, etc.</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#Quantity"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P3744"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P3744"/>
@@ -5475,14 +4999,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P3744"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P3744"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P3744"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P3744"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P3744"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P3744"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P3744"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P3744"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P3744"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P3744"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P3744"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P3744">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -5534,9 +5054,7 @@
     <rdfs:label xml:lang="en">Twitter user numeric ID</rdfs:label>
     <skos:prefLabel xml:lang="en">Twitter user numeric ID</skos:prefLabel>
     <schema:name xml:lang="en">Twitter user numeric ID</schema:name>
-    <schema:description xml:lang="en">numeric identifier for a user on Twitter; use as qualifier for
-      P2002 &quot;Twitter username&quot;
-    </schema:description>
+    <schema:description xml:lang="en">numeric identifier for a user on Twitter; use as qualifier for P2002 &quot;Twitter username&quot;</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P6552"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P6552"/>
@@ -5547,14 +5065,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P6552"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P6552"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P6552"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P6552"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P6552"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P6552"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P6552"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P6552"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P6552"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P6552"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P6552"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P6552">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -5606,9 +5120,7 @@
     <rdfs:label xml:lang="en">point in time</rdfs:label>
     <skos:prefLabel xml:lang="en">point in time</skos:prefLabel>
     <schema:name xml:lang="en">point in time</schema:name>
-    <schema:description xml:lang="en">time and date something took place, existed or a statement was
-      true
-    </schema:description>
+    <schema:description xml:lang="en">time and date something took place, existed or a statement was true</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#Time"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P585"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P585"/>
@@ -5658,9 +5170,7 @@
     <rdfs:label xml:lang="en">start time</rdfs:label>
     <skos:prefLabel xml:lang="en">start time</skos:prefLabel>
     <schema:name xml:lang="en">start time</schema:name>
-    <schema:description xml:lang="en">time an item begins to exist or a statement starts being
-      valid
-    </schema:description>
+    <schema:description xml:lang="en">time an item begins to exist or a statement starts being valid</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#Time"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P580"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P580"/>
@@ -5710,9 +5220,7 @@
     <rdfs:label xml:lang="en">reference URL</rdfs:label>
     <skos:prefLabel xml:lang="en">reference URL</skos:prefLabel>
     <schema:name xml:lang="en">reference URL</schema:name>
-    <schema:description xml:lang="en">should be used for Internet URLs as references. Use &quot;Wikimedia
-      import URL&quot; (P4656) for imports from WMF sites
-    </schema:description>
+    <schema:description xml:lang="en">should be used for Internet URLs as references. Use &quot;Wikimedia import URL&quot; (P4656) for imports from WMF sites</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#Url"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P854"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P854"/>
@@ -5762,9 +5270,7 @@
     <rdfs:label xml:lang="en">DOI</rdfs:label>
     <skos:prefLabel xml:lang="en">DOI</skos:prefLabel>
     <schema:name xml:lang="en">DOI</schema:name>
-    <schema:description xml:lang="en">serial code used to uniquely identify digital objects like
-      academic papers (use upper case letters only)
-    </schema:description>
+    <schema:description xml:lang="en">serial code used to uniquely identify digital objects like academic papers (use upper case letters only)</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#ExternalId"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P356"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P356"/>
@@ -5775,14 +5281,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P356"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P356"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P356"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P356"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P356"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P356"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P356"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P356"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P356"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P356"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P356"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P356">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -5855,10 +5357,7 @@
     <rdfs:label xml:lang="en">Wikimedia import URL</rdfs:label>
     <skos:prefLabel xml:lang="en">Wikimedia import URL</skos:prefLabel>
     <schema:name xml:lang="en">Wikimedia import URL</schema:name>
-    <schema:description xml:lang="en">URL of source to indicate the page or revision of an import
-      source from another Wikimedia project (except actual references, such as Wikisource source
-      texts). Use instead of &quot;reference URL&quot; (P854). Permalinks are preferred.
-    </schema:description>
+    <schema:description xml:lang="en">URL of source to indicate the page or revision of an import source from another Wikimedia project (except actual references, such as Wikisource source texts). Use instead of &quot;reference URL&quot; (P854). Permalinks are preferred.</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#Url"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P4656"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P4656"/>
@@ -5908,19 +5407,14 @@
     <rdfs:label xml:lang="en">Dutch</rdfs:label>
     <skos:prefLabel xml:lang="en">Dutch</skos:prefLabel>
     <schema:name xml:lang="en">Dutch</schema:name>
-    <schema:description xml:lang="en">West Germanic language originating in the Netherlands and
-      Belgium
-    </schema:description>
+    <schema:description xml:lang="en">West Germanic language originating in the Netherlands and Belgium</schema:description>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/P407">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Property"/>
     <rdfs:label xml:lang="en">language of work or name</rdfs:label>
     <skos:prefLabel xml:lang="en">language of work or name</skos:prefLabel>
     <schema:name xml:lang="en">language of work or name</schema:name>
-    <schema:description xml:lang="en">language associated with this creative work (such as books,
-      shows, songs, or websites) or a name (for persons use &quot;native language&quot; (P103) and
-      &quot;languages spoken, written or signed&quot; (P1412))
-    </schema:description>
+    <schema:description xml:lang="en">language associated with this creative work (such as books, shows, songs, or websites) or a name (for persons use &quot;native language&quot; (P103) and &quot;languages spoken, written or signed&quot; (P1412))</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#WikibaseItem"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P407"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P407"/>
@@ -5970,9 +5464,7 @@
     <rdfs:label xml:lang="en">title</rdfs:label>
     <skos:prefLabel xml:lang="en">title</skos:prefLabel>
     <schema:name xml:lang="en">title</schema:name>
-    <schema:description xml:lang="en">published name of a work, such as a newspaper article, a
-      literary work, piece of music, a website, or a performance work
-    </schema:description>
+    <schema:description xml:lang="en">published name of a work, such as a newspaper article, a literary work, piece of music, a website, or a performance work</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#Monolingualtext"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P1476"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P1476"/>
@@ -6029,8 +5521,7 @@
     <rdfs:label xml:lang="en">applies to part</rdfs:label>
     <skos:prefLabel xml:lang="en">applies to part</skos:prefLabel>
     <schema:name xml:lang="en">applies to part</schema:name>
-    <schema:description xml:lang="en">part, aspect, or form of the item to which the claim applies
-    </schema:description>
+    <schema:description xml:lang="en">part, aspect, or form of the item to which the claim applies</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#WikibaseItem"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P518"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P518"/>
@@ -6077,57 +5568,31 @@
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q76889548">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Item"/>
-    <rdfs:label xml:lang="en">Survey of GLAM open access policy and practice, version of October 31,
-      2019
-    </rdfs:label>
-    <skos:prefLabel xml:lang="en">Survey of GLAM open access policy and practice, version of October
-      31, 2019
-    </skos:prefLabel>
-    <schema:name xml:lang="en">Survey of GLAM open access policy and practice, version of October
-      31, 2019
-    </schema:name>
-    <schema:description xml:lang="en">October 31, 2019 backup of the OpenGLAM Survey by Andrea
-      Wallace and Douglas McCarthy
-    </schema:description>
+    <rdfs:label xml:lang="en">Survey of GLAM open access policy and practice, version of October 31, 2019</rdfs:label>
+    <skos:prefLabel xml:lang="en">Survey of GLAM open access policy and practice, version of October 31, 2019</skos:prefLabel>
+    <schema:name xml:lang="en">Survey of GLAM open access policy and practice, version of October 31, 2019</schema:name>
+    <schema:description xml:lang="en">October 31, 2019 backup of the OpenGLAM Survey by Andrea Wallace and Douglas McCarthy</schema:description>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q97730483">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Item"/>
-    <rdfs:label xml:lang="en">Survey of GLAM open access policy and practice, version of April 30,
-      2020
-    </rdfs:label>
-    <skos:prefLabel xml:lang="en">Survey of GLAM open access policy and practice, version of April
-      30, 2020
-    </skos:prefLabel>
-    <schema:name xml:lang="en">Survey of GLAM open access policy and practice, version of April 30,
-      2020
-    </schema:name>
-    <schema:description xml:lang="en">April 30, 2020 backup of the OpenGLAM Survey by Andrea Wallace
-      and Douglas McCarthy
-    </schema:description>
+    <rdfs:label xml:lang="en">Survey of GLAM open access policy and practice, version of April 30, 2020</rdfs:label>
+    <skos:prefLabel xml:lang="en">Survey of GLAM open access policy and practice, version of April 30, 2020</skos:prefLabel>
+    <schema:name xml:lang="en">Survey of GLAM open access policy and practice, version of April 30, 2020</schema:name>
+    <schema:description xml:lang="en">April 30, 2020 backup of the OpenGLAM Survey by Andrea Wallace and Douglas McCarthy</schema:description>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/Q107866137">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Item"/>
-    <rdfs:label xml:lang="en">Survey of GLAM open access policy and practice, version of August 3,
-      2021
-    </rdfs:label>
-    <skos:prefLabel xml:lang="en">Survey of GLAM open access policy and practice, version of August
-      3, 2021
-    </skos:prefLabel>
-    <schema:name xml:lang="en">Survey of GLAM open access policy and practice, version of August 3,
-      2021
-    </schema:name>
-    <schema:description xml:lang="en">August 3, 2021 backup of the Open GLAM Survey by Andrea
-      Wallace and Douglas McCarthy
-    </schema:description>
+    <rdfs:label xml:lang="en">Survey of GLAM open access policy and practice, version of August 3, 2021</rdfs:label>
+    <skos:prefLabel xml:lang="en">Survey of GLAM open access policy and practice, version of August 3, 2021</skos:prefLabel>
+    <schema:name xml:lang="en">Survey of GLAM open access policy and practice, version of August 3, 2021</schema:name>
+    <schema:description xml:lang="en">August 3, 2021 backup of the Open GLAM Survey by Andrea Wallace and Douglas McCarthy</schema:description>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/entity/P1810">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Property"/>
     <rdfs:label xml:lang="en">named as</rdfs:label>
     <skos:prefLabel xml:lang="en">named as</skos:prefLabel>
     <schema:name xml:lang="en">named as</schema:name>
-    <schema:description xml:lang="en">name by which a subject is recorded in a database or mentioned
-      as a contributor of a work
-    </schema:description>
+    <schema:description xml:lang="en">name by which a subject is recorded in a database or mentioned as a contributor of a work</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#String"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P1810"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P1810"/>
@@ -6177,9 +5642,7 @@
     <rdfs:label xml:lang="en">number of works</rdfs:label>
     <skos:prefLabel xml:lang="en">number of works</skos:prefLabel>
     <schema:name xml:lang="en">number of works</schema:name>
-    <schema:description xml:lang="en">qualifier on identifiers, eg for creators or locations, giving
-      the number of works in the external database associated with the subject of the identifier
-    </schema:description>
+    <schema:description xml:lang="en">qualifier on identifiers, eg for creators or locations, giving the number of works in the external database associated with the subject of the identifier</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#Quantity"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P3740"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P3740"/>
@@ -6190,14 +5653,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P3740"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P3740"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P3740"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P3740"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P3740"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P3740"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P3740"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P3740"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P3740"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P3740"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P3740"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P3740">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -6249,9 +5708,7 @@
     <rdfs:label xml:lang="en">number of viewers/listeners</rdfs:label>
     <skos:prefLabel xml:lang="en">number of viewers/listeners</skos:prefLabel>
     <schema:name xml:lang="en">number of viewers/listeners</schema:name>
-    <schema:description xml:lang="en">number of viewers of a television or broadcasting program; web
-      traffic on websites
-    </schema:description>
+    <schema:description xml:lang="en">number of viewers of a television or broadcasting program; web traffic on websites</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#Quantity"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P5436"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P5436"/>
@@ -6262,14 +5719,10 @@
     <wikibase:reference rdf:resource="http://www.wikidata.org/prop/reference/P5436"/>
     <wikibase:referenceValue rdf:resource="http://www.wikidata.org/prop/reference/value/P5436"/>
     <wikibase:novalue rdf:resource="http://www.wikidata.org/prop/novalue/P5436"/>
-    <wikibase:directClaimNormalized
-      rdf:resource="http://www.wikidata.org/prop/direct-normalized/P5436"/>
-    <wikibase:statementValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P5436"/>
-    <wikibase:qualifierValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P5436"/>
-    <wikibase:referenceValueNormalized
-      rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P5436"/>
+    <wikibase:directClaimNormalized rdf:resource="http://www.wikidata.org/prop/direct-normalized/P5436"/>
+    <wikibase:statementValueNormalized rdf:resource="http://www.wikidata.org/prop/statement/value-normalized/P5436"/>
+    <wikibase:qualifierValueNormalized rdf:resource="http://www.wikidata.org/prop/qualifier/value-normalized/P5436"/>
+    <wikibase:referenceValueNormalized rdf:resource="http://www.wikidata.org/prop/reference/value-normalized/P5436"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/prop/P5436">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -6328,8 +5781,7 @@
     <rdfs:label xml:lang="en">protocol</rdfs:label>
     <skos:prefLabel xml:lang="en">protocol</skos:prefLabel>
     <schema:name xml:lang="en">protocol</schema:name>
-    <schema:description xml:lang="en">communication protocol to use to access a dataset or service
-    </schema:description>
+    <schema:description xml:lang="en">communication protocol to use to access a dataset or service</schema:description>
     <wikibase:propertyType rdf:resource="http://wikiba.se/ontology#WikibaseItem"/>
     <wikibase:directClaim rdf:resource="http://www.wikidata.org/prop/direct/P2700"/>
     <wikibase:claim rdf:resource="http://www.wikidata.org/prop/P2700"/>
@@ -6383,432 +5835,299 @@
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/29700b6a1745ff311229e30533e81777">
     <rdf:type rdf:resource="http://wikiba.se/ontology#GlobecoordinateValue"/>
-    <wikibase:geoLatitude rdf:datatype="http://www.w3.org/2001/XMLSchema#double">52.16472222
-    </wikibase:geoLatitude>
-    <wikibase:geoLongitude rdf:datatype="http://www.w3.org/2001/XMLSchema#double">4.47333333
-    </wikibase:geoLongitude>
-    <wikibase:geoPrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#double">
-      0.00027777777777778
-    </wikibase:geoPrecision>
+    <wikibase:geoLatitude rdf:datatype="http://www.w3.org/2001/XMLSchema#double">52.16472222</wikibase:geoLatitude>
+    <wikibase:geoLongitude rdf:datatype="http://www.w3.org/2001/XMLSchema#double">4.47333333</wikibase:geoLongitude>
+    <wikibase:geoPrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#double">0.00027777777777778</wikibase:geoPrecision>
     <wikibase:geoGlobe rdf:resource="http://www.wikidata.org/entity/Q2"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/df2e3e6ccf622e2f0ebb5ed187399afd">
     <rdf:type rdf:resource="http://wikiba.se/ontology#QuantityValue"/>
-    <wikibase:quantityAmount rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">+271000
-    </wikibase:quantityAmount>
+    <wikibase:quantityAmount rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">+271000</wikibase:quantityAmount>
     <wikibase:quantityUnit rdf:resource="http://www.wikidata.org/entity/Q199"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/18dc9bce774a36e48cd1ff21d920d1a6">
     <rdf:type rdf:resource="http://wikiba.se/ontology#QuantityValue"/>
-    <wikibase:quantityAmount rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">+12878
-    </wikibase:quantityAmount>
+    <wikibase:quantityAmount rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">+12878</wikibase:quantityAmount>
     <wikibase:quantityUnit rdf:resource="http://www.wikidata.org/entity/Q199"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/6847e9ab8ee489b1fc25e677d7321c76">
     <rdf:type rdf:resource="http://wikiba.se/ontology#QuantityValue"/>
-    <wikibase:quantityAmount rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">+1580
-    </wikibase:quantityAmount>
+    <wikibase:quantityAmount rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">+1580</wikibase:quantityAmount>
     <wikibase:quantityUnit rdf:resource="http://www.wikidata.org/entity/Q199"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/018361ff36633e5946c23d610c93ce1b">
     <rdf:type rdf:resource="http://wikiba.se/ontology#QuantityValue"/>
-    <wikibase:quantityAmount rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">+406
-    </wikibase:quantityAmount>
+    <wikibase:quantityAmount rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">+406</wikibase:quantityAmount>
     <wikibase:quantityUnit rdf:resource="http://www.wikidata.org/entity/Q199"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/3bc1e9007990add52c8fb597b5e96bb6">
     <rdf:type rdf:resource="http://wikiba.se/ontology#QuantityValue"/>
-    <wikibase:quantityAmount rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">+2048173
-    </wikibase:quantityAmount>
+    <wikibase:quantityAmount rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">+2048173</wikibase:quantityAmount>
     <wikibase:quantityUnit rdf:resource="http://www.wikidata.org/entity/Q199"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/0120775ef455cb41abd311380172b537">
     <rdf:type rdf:resource="http://wikiba.se/ontology#QuantityValue"/>
-    <wikibase:quantityAmount rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">+14386
-    </wikibase:quantityAmount>
+    <wikibase:quantityAmount rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">+14386</wikibase:quantityAmount>
     <wikibase:quantityUnit rdf:resource="http://www.wikidata.org/entity/Q199"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/f987783e1f9c9fa0cb0b774d330af52d">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2013-10-28T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-10-28T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/d52720d16973a301b0ccd441d060aada">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2020-03-21T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-03-21T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/7bf2401d3dccce9bcf9d65061b36d9c5">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2015-10-06T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-06T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/eb0a73e8075db328523be97d99b44c4d">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      1984-01-01T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1984-01-01T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/d6393f334ebb1e3e38651406f16c1a39">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2018-05-10T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-05-10T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/0f06e57ad4e5a1b8274594f8c83ff0e4">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2008-09-08T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2008-09-08T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/c40da1f66114bccdb50c5cc268122fa8">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2020-05-07T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-05-07T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/37062c5b89ce4b78f41f8570ca80b6ad">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2017-12-08T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-12-08T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/63009268190f305220ac4f0ff5489919">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2018-08-31T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-08-31T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/ecab97dfa32685cf7f717e2f3f5b3ef6">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2018-09-02T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-02T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/1c9551a398cfb51623c28b80416004d3">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2019-01-01T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-01T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/447c4991e1f62b61a509db92d5b4e735">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2019-10-31T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-10-31T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/0c5f07ea6b6e92dd89849b978518123d">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2020-04-30T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-04-30T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/b3eedd3c3bfc9343bcd60b5430dc341d">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2021-08-03T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-03T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/42e6bf9c258c9e00238f18929a602860">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2019-11-30T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-11-30T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/370168073e729ba2b2b7f5cf1291e6c6">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2020-07-27T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-07-27T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/d7f52187a8ce30f7ec8a487d174af8aa">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2021-08-04T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-04T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/5ba0fe150d08cac57abf917ede2d1c04">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2020-02-24T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-02-24T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/3e03de24647d0a0427ea2c0bd25f5303">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2020-03-07T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-03-07T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/f0f58c3bf28a8de4416a66ce21126f6d">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2007-12-17T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2007-12-17T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/3c3accbb8e91a57dbeeb9d654628cd1a">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2020-12-11T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-11T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/50ed2538d5dcbea402a38ff688301e4b">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2020-06-23T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-06-23T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/d40cb13acf8001d779efbb0c45cb42f0">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2021-01-07T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-01-07T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/b453138f20fbe9c871fe8925de184e5d">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2021-01-01T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-01-01T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/4c37b130fe96eb78d6c7df065d869f28">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2021-05-19T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-19T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.wikidata.org/value/068defc300d06ed22eb72f44c2fe8914">
     <rdf:type rdf:resource="http://wikiba.se/ontology#TimeValue"/>
-    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-      2021-01-01T00:00:00Z
-    </wikibase:timeValue>
-    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9
-    </wikibase:timePrecision>
-    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0
-    </wikibase:timeTimezone>
+    <wikibase:timeValue rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-01-01T00:00:00Z</wikibase:timeValue>
+    <wikibase:timePrecision rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</wikibase:timePrecision>
+    <wikibase:timeTimezone rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</wikibase:timeTimezone>
     <wikibase:timeCalendarModel rdf:resource="http://www.wikidata.org/entity/Q1985727"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/732ec1c90a6f0694c7db9a71bf09fe7f2b674172">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/732ec1c90a6f0694c7db9a71bf09fe7f2b674172">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P143 rdf:resource="http://www.wikidata.org/entity/Q10000"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/9a24f7c0208b05d6be97077d855671d1dfdbc0dd">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/9a24f7c0208b05d6be97077d855671d1dfdbc0dd">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P143 rdf:resource="http://www.wikidata.org/entity/Q48183"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/2b00cb481cddcac7623114367489b5c194901c4a">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/2b00cb481cddcac7623114367489b5c194901c4a">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P248 rdf:resource="http://www.wikidata.org/entity/Q15241312"/>
     <pr:P577 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-10-28T00:00:00Z</pr:P577>
     <prv:P577 rdf:resource="http://www.wikidata.org/value/f987783e1f9c9fa0cb0b774d330af52d"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/fa278ebfc458360e5aed63d5058cca83c46134f1">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/fa278ebfc458360e5aed63d5058cca83c46134f1">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P143 rdf:resource="http://www.wikidata.org/entity/Q328"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/2d1bdb40c9ef573a185deaf8ac541b5a7a1d1575">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/2d1bdb40c9ef573a185deaf8ac541b5a7a1d1575">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P248 rdf:resource="http://www.wikidata.org/entity/Q62338567"/>
     <pr:P6698>ナチュラリス生物多様性センター</pr:P6698>
-    <prn:P6698
-      rdf:resource="https://jpsearch.go.jp/entity/chname/%E3%83%8A%E3%83%81%E3%83%A5%E3%83%A9%E3%83%AA%E3%82%B9%E7%94%9F%E7%89%A9%E5%A4%9A%E6%A7%98%E6%80%A7%E3%82%BB%E3%83%B3%E3%82%BF%E3%83%BC"/>
+    <prn:P6698 rdf:resource="https://jpsearch.go.jp/entity/chname/%E3%83%8A%E3%83%81%E3%83%A5%E3%83%A9%E3%83%AA%E3%82%B9%E7%94%9F%E7%89%A9%E5%A4%9A%E6%A7%98%E6%80%A7%E3%82%BB%E3%83%B3%E3%82%BF%E3%83%BC"/>
     <pr:P813 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-03-21T00:00:00Z</pr:P813>
     <prv:P813 rdf:resource="http://www.wikidata.org/value/d52720d16973a301b0ccd441d060aada"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/cfc3fc925ddc31f71c67244753346f9fca7ab7d7">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/cfc3fc925ddc31f71c67244753346f9fca7ab7d7">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P248 rdf:resource="http://www.wikidata.org/entity/Q15241312"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/4533e325b4161189dcba02b6a92f6c4533327637">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/4533e325b4161189dcba02b6a92f6c4533327637">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P248 rdf:resource="http://www.wikidata.org/entity/Q54919"/>
     <pr:P813 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-06T00:00:00Z</pr:P813>
     <prv:P813 rdf:resource="http://www.wikidata.org/value/7bf2401d3dccce9bcf9d65061b36d9c5"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/bdc392da4402f32ffe5912f6f5d0413e12c781c0">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/bdc392da4402f32ffe5912f6f5d0413e12c781c0">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P854 rdf:resource="https://www.naturalis.nl/"/>
     <pr:P813 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-05-07T00:00:00Z</pr:P813>
     <prv:P813 rdf:resource="http://www.wikidata.org/value/c40da1f66114bccdb50c5cc268122fa8"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/f20e7cc1dc95f8af90470df9ddea266baf12be00">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/f20e7cc1dc95f8af90470df9ddea266baf12be00">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P356>10.6084/M9.FIGSHARE.4539889</pr:P356>
     <prn:P356 rdf:resource="http://dx.doi.org/10.6084/M9.FIGSHARE.4539889"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/45e8fa2e37c421b7e5970029041dbdeac9824284">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/45e8fa2e37c421b7e5970029041dbdeac9824284">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P356>10.5281/ZENODO.758080</pr:P356>
     <prn:P356 rdf:resource="http://dx.doi.org/10.5281/ZENODO.758080"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/0922b18cbd5b72d3cb146c310184634e70883a6d">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/0922b18cbd5b72d3cb146c310184634e70883a6d">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
-    <pr:P854
-      rdf:resource="https://apps.db.ripe.net/search/lookup.html?source=ripe&amp;key=2001:610:1910::/48&amp;type=inet6num"/>
+    <pr:P854 rdf:resource="https://apps.db.ripe.net/search/lookup.html?source=ripe&amp;key=2001:610:1910::/48&amp;type=inet6num"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/fcb7e912b5609935e9aab460323fd4b0050ab3bf">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/fcb7e912b5609935e9aab460323fd4b0050ab3bf">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P854 rdf:resource="http://api.crossref.org/members/2084"/>
     <pr:P813 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-12-08T00:00:00Z</pr:P813>
     <prv:P813 rdf:resource="http://www.wikidata.org/value/37062c5b89ce4b78f41f8570ca80b6ad"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/40fdc7f3ce7f6771a8f285a1267bfc3f3de154d9">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/40fdc7f3ce7f6771a8f285a1267bfc3f3de154d9">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P248 rdf:resource="http://www.wikidata.org/entity/Q53869345"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/a1914c8952a5bc482eafeb26be4fda504fe701f9">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/a1914c8952a5bc482eafeb26be4fda504fe701f9">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P248 rdf:resource="http://www.wikidata.org/entity/Q53705036"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/f507edf93a227371b28a18269a56a7189f6d43f3">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/f507edf93a227371b28a18269a56a7189f6d43f3">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P143 rdf:resource="http://www.wikidata.org/entity/Q199698"/>
-    <pr:P4656
-      rdf:resource="https://uk.wikipedia.org/w/index.php?title=Центр_біорізноманіття_«Натураліс»&amp;oldid=15823075"/>
+    <pr:P4656 rdf:resource="https://uk.wikipedia.org/w/index.php?title=Центр_біорізноманіття_«Натураліс»&amp;oldid=15823075"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/56da4ad0e0d7110e28d9c4ee68beeb3d9db64008">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/56da4ad0e0d7110e28d9c4ee68beeb3d9db64008">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P854 rdf:resource="https://www.museumkaart.nl/museumkaartgeldig"/>
     <pr:P407 rdf:resource="http://www.wikidata.org/entity/Q7411"/>
@@ -6816,110 +6135,92 @@
     <prv:P813 rdf:resource="http://www.wikidata.org/value/63009268190f305220ac4f0ff5489919"/>
     <pr:P1476 xml:lang="nl">Waar is de Museumkaart geldig?</pr:P1476>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/0ba1dd7ba8fa48f5efddf6c41b2c39949c8854ae">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/0ba1dd7ba8fa48f5efddf6c41b2c39949c8854ae">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P854 rdf:resource="https://www.naturalis.nl/museum/praktische-informatie"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/de93c5991fe66e1f3ea65ffd7ef6af8084d830a4">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/de93c5991fe66e1f3ea65ffd7ef6af8084d830a4">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P407 rdf:resource="http://www.wikidata.org/entity/Q7411"/>
     <pr:P813 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-09-02T00:00:00Z</pr:P813>
     <prv:P813 rdf:resource="http://www.wikidata.org/value/ecab97dfa32685cf7f717e2f3f5b3ef6"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/091310947d434f969669d6f86877179ab49df8b5">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/091310947d434f969669d6f86877179ab49df8b5">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P854 rdf:resource="https://neutelings-riedijk.com/naturalis-biodiversity-center"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/4a86fdea19c76da6803f71b49648769d3e6448a1">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/4a86fdea19c76da6803f71b49648769d3e6448a1">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P854 rdf:resource="https://architectenweb.nl/nieuws/artikel.aspx?ID=40370"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/0e3b48ffd16176acaf88177cd865f1e389084c77">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/0e3b48ffd16176acaf88177cd865f1e389084c77">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P248 rdf:resource="http://www.wikidata.org/entity/Q76889548"/>
     <pr:P854 rdf:resource="https://archive.org/details/OpenGLAM_Survey_20191031"/>
     <pr:P813 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-11-30T00:00:00Z</pr:P813>
     <prv:P813 rdf:resource="http://www.wikidata.org/value/42e6bf9c258c9e00238f18929a602860"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/1f94b9fc199ff31be06b906fd8ec1e9043866ba2">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/1f94b9fc199ff31be06b906fd8ec1e9043866ba2">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P248 rdf:resource="http://www.wikidata.org/entity/Q97730483"/>
     <pr:P854 rdf:resource="https://archive.org/details/OpenGLAM_Survey_20200430"/>
     <pr:P813 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-07-27T00:00:00Z</pr:P813>
     <prv:P813 rdf:resource="http://www.wikidata.org/value/370168073e729ba2b2b7f5cf1291e6c6"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/5119aea74673e8aa798b0743e236d70ba0a0e644">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/5119aea74673e8aa798b0743e236d70ba0a0e644">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P248 rdf:resource="http://www.wikidata.org/entity/Q107866137"/>
     <pr:P854 rdf:resource="https://archive.org/details/OpenGLAM_Survey_20210803"/>
     <pr:P813 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-04T00:00:00Z</pr:P813>
     <prv:P813 rdf:resource="http://www.wikidata.org/value/d7f52187a8ce30f7ec8a487d174af8aa"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/6e34c4992adc896790754535d2dd43cafaf9bebe">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/6e34c4992adc896790754535d2dd43cafaf9bebe">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P854 rdf:resource="https://cetaf.org/members/cetaf-members"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/3693dee5af6ce7807b747a592c25c6c7d68c180d">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/3693dee5af6ce7807b747a592c25c6c7d68c180d">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P854 rdf:resource="https://www.tdwg.org/about/membership/"/>
     <pr:P813 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-02-24T00:00:00Z</pr:P813>
     <prv:P813 rdf:resource="http://www.wikidata.org/value/5ba0fe150d08cac57abf917ede2d1c04"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/07d727fd8f1a3903c1acfb8fae6a2cd6461219d8">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/07d727fd8f1a3903c1acfb8fae6a2cd6461219d8">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
-    <pr:P854
-      rdf:resource="https://geheugen.delpher.nl/nl/geheugen/pages/instelling/Naturalis+Biodiversity+Center"/>
+    <pr:P854 rdf:resource="https://geheugen.delpher.nl/nl/geheugen/pages/instelling/Naturalis+Biodiversity+Center"/>
     <pr:P813 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-03-07T00:00:00Z</pr:P813>
     <prv:P813 rdf:resource="http://www.wikidata.org/value/3e03de24647d0a0427ea2c0bd25f5303"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/b72b0c69b9ff36a930131ec263e7241d36a097c0">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/b72b0c69b9ff36a930131ec263e7241d36a097c0">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P214>132063008</pr:P214>
     <prn:P214 rdf:resource="http://viaf.org/viaf/132063008"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/9388e42c81d6c0e9f013d673a876f6c72c8ba686">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/9388e42c81d6c0e9f013d673a876f6c72c8ba686">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P214>305227246</pr:P214>
     <prn:P214 rdf:resource="http://viaf.org/viaf/305227246"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/19f351fefd610a866859a3ffe6a2a2413936521f">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/19f351fefd610a866859a3ffe6a2a2413936521f">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P854 rdf:resource="https://orcid.org/signin"/>
     <pr:P813 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-06-23T00:00:00Z</pr:P813>
     <prv:P813 rdf:resource="http://www.wikidata.org/value/50ed2538d5dcbea402a38ff688301e4b"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/40462db33d6dce09bcb5b80684506375f6013475">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/40462db33d6dce09bcb5b80684506375f6013475">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P143 rdf:resource="http://www.wikidata.org/entity/Q206855"/>
     <pr:P4656 rdf:resource="https://ru.wikipedia.org/?oldid=107362905"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/838150ba9d3e26e34caf47b0a92a34049a1421e2">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/838150ba9d3e26e34caf47b0a92a34049a1421e2">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P813 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-01-01T00:00:00Z</pr:P813>
     <prv:P813 rdf:resource="http://www.wikidata.org/value/b453138f20fbe9c871fe8925de184e5d"/>
     <pr:P854 rdf:resource="https://n2t.net/e/pub/naan_registry.txt"/>
   </rdf:Description>
-  <rdf:Description
-    rdf:about="http://www.wikidata.org/reference/a73243e27f42de75ca85e1ac6b082e8f3c7e89f9">
+  <rdf:Description rdf:about="http://www.wikidata.org/reference/a73243e27f42de75ca85e1ac6b082e8f3c7e89f9">
     <rdf:type rdf:resource="http://wikiba.se/ontology#Reference"/>
     <pr:P248 rdf:resource="http://www.wikidata.org/entity/Q73357989"/>
-    <pr:P854
-      rdf:resource="https://docs.google.com/spreadsheets/d/1WPS-KJptUJ-o8SXtg00llcxq0IKJu8eO6Ege_GrLaNc"/>
+    <pr:P854 rdf:resource="https://docs.google.com/spreadsheets/d/1WPS-KJptUJ-o8SXtg00llcxq0IKJu8eO6Ege_GrLaNc"/>
     <pr:P813 rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-05-19T00:00:00Z</pr:P813>
     <prv:P813 rdf:resource="http://www.wikidata.org/value/4c37b130fe96eb78d6c7df065d869f28"/>
   </rdf:Description>

--- a/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/wikidata/WikidataDereferenceService.java
+++ b/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/wikidata/WikidataDereferenceService.java
@@ -78,14 +78,14 @@ public class WikidataDereferenceService implements Dereferencer, InitializingBea
    * (see e.g. https://community.oracle.com/tech/developers/discussion/1627333/premature-end-of-file-error-using-same-inputstream-from-two-functions)
    */
   private void setupXsltTransformer() {
-    InputStream transformerXSL =
-        WikidataDereferenceService.class.getResourceAsStream("/wkd2org.xsl");
     TransformerFactory transformerFactory = new net.sf.saxon.TransformerFactoryImpl();
 
     this.transformer =
         ThreadLocal.withInitial(
             () -> {
               try {
+                InputStream transformerXSL =
+                    WikidataDereferenceService.class.getResourceAsStream("/wkd2org.xsl");
                 Transformer newTransformer =
                     transformerFactory.newTransformer(new StreamSource(transformerXSL));
                 newTransformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");

--- a/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/zoho/ZohoAccessClient.java
+++ b/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/zoho/ZohoAccessClient.java
@@ -46,7 +46,7 @@ public class ZohoAccessClient {
    * @param zohoEmail the zoho email
    * @param clientId the zoho client id
    * @param clientSecret the zoho client secret
-   * @param refreshToken the zoho initial grant token
+   * @param refreshToken the zoho initial refresh token
    * @param redirectUrl the registered zoho redirect url
    */
   public ZohoAccessClient(
@@ -55,7 +55,8 @@ public class ZohoAccessClient {
       String clientId,
       String clientSecret,
       String refreshToken,
-      String redirectUrl) {
+      String redirectUrl)
+      throws ZohoException {
     try {
       UserSignature userSignature = new UserSignature(zohoEmail);
       Token token =
@@ -68,7 +69,7 @@ public class ZohoAccessClient {
       Initializer.initialize(
           userSignature, environment, token, tokenStore, sdkConfig, resourcePath);
     } catch (SDKException e) {
-      LOGGER.warn("Exception during initialize", e);
+      throw new ZohoException("Error initializing ZohoAccessClient", e);
     }
   }
 

--- a/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/zoho/ZohoAccessClient.java
+++ b/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/zoho/ZohoAccessClient.java
@@ -1,10 +1,11 @@
 package eu.europeana.entitymanagement.zoho;
 
+import static eu.europeana.entitymanagement.zoho.utils.ZohoUtils.getZohoRecords;
+
 import com.zoho.api.authenticator.OAuthToken;
 import com.zoho.api.authenticator.OAuthToken.TokenType;
 import com.zoho.api.authenticator.Token;
 import com.zoho.api.authenticator.store.TokenStore;
-import com.zoho.crm.api.HeaderMap;
 import com.zoho.crm.api.Initializer;
 import com.zoho.crm.api.ParameterMap;
 import com.zoho.crm.api.SDKConfig;
@@ -12,30 +13,15 @@ import com.zoho.crm.api.UserSignature;
 import com.zoho.crm.api.dc.DataCenter.Environment;
 import com.zoho.crm.api.dc.USDataCenter;
 import com.zoho.crm.api.exception.SDKException;
-import com.zoho.crm.api.record.DeletedRecord;
-import com.zoho.crm.api.record.DeletedRecordsHandler;
-import com.zoho.crm.api.record.DeletedRecordsWrapper;
 import com.zoho.crm.api.record.Record;
 import com.zoho.crm.api.record.RecordOperations;
-import com.zoho.crm.api.record.RecordOperations.GetDeletedRecordsParam;
-import com.zoho.crm.api.record.RecordOperations.GetRecordsHeader;
-import com.zoho.crm.api.record.RecordOperations.GetRecordsParam;
 import com.zoho.crm.api.record.RecordOperations.SearchRecordsParam;
 import com.zoho.crm.api.record.ResponseHandler;
-import com.zoho.crm.api.record.ResponseWrapper;
 import com.zoho.crm.api.util.APIResponse;
 import eu.europeana.entitymanagement.utils.EntityRecordUtils;
 import eu.europeana.entitymanagement.zoho.utils.ZohoConstants;
 import eu.europeana.entitymanagement.zoho.utils.ZohoException;
-import java.time.OffsetDateTime;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -43,8 +29,6 @@ import org.apache.logging.log4j.Logger;
 public class ZohoAccessClient {
 
   private static final Logger LOGGER = LogManager.getLogger(ZohoAccessClient.class);
-
-  private static final int ITEMS_PER_PAGE = 200;
 
   /**
    * Constructor with all parameters.
@@ -62,7 +46,7 @@ public class ZohoAccessClient {
    * @param zohoEmail the zoho email
    * @param clientId the zoho client id
    * @param clientSecret the zoho client secret
-   * @param grandToken the zoho initial grant token
+   * @param refreshToken the zoho initial grant token
    * @param redirectUrl the registered zoho redirect url
    */
   public ZohoAccessClient(
@@ -70,12 +54,12 @@ public class ZohoAccessClient {
       String zohoEmail,
       String clientId,
       String clientSecret,
-      String grandToken,
+      String refreshToken,
       String redirectUrl) {
     try {
       UserSignature userSignature = new UserSignature(zohoEmail);
       Token token =
-          new OAuthToken(clientId, clientSecret, grandToken, TokenType.GRANT, redirectUrl);
+          new OAuthToken(clientId, clientSecret, refreshToken, TokenType.REFRESH, redirectUrl);
       SDKConfig sdkConfig =
           new SDKConfig.Builder().setAutoRefreshFields(false).setPickListValidation(true).build();
       Environment environment = USDataCenter.PRODUCTION;
@@ -88,71 +72,7 @@ public class ZohoAccessClient {
     }
   }
 
-  public Optional<Record> getZohoRecordContactByEmail(String email) throws ZohoException {
-    try {
-      RecordOperations recordOperations = new RecordOperations();
-      ParameterMap paramInstance = new ParameterMap();
-      paramInstance.add(SearchRecordsParam.EMAIL, email);
-      APIResponse<ResponseHandler> response =
-          recordOperations.searchRecords(ZohoConstants.CONTACTS_MODULE_NAME, paramInstance);
-      return getZohoRecord(response);
-    } catch (SDKException e) {
-      throw new ZohoException("Zoho search by email threw an exception", e);
-    }
-  }
-
-  public Optional<Record> getZohoRecordOrganizationByName(String organizationName)
-      throws ZohoException {
-    try {
-      RecordOperations recordOperations = new RecordOperations();
-      ParameterMap paramInstance = new ParameterMap();
-      paramInstance.add(
-          SearchRecordsParam.CRITERIA,
-          String.format(
-              ZohoConstants.ZOHO_OPERATION_FORMAT_STRING,
-              ZohoConstants.ACCOUNT_NAME_FIELD,
-              ZohoConstants.EQUALS_OPERATION,
-              organizationName));
-
-      APIResponse<ResponseHandler> response =
-          recordOperations.searchRecords(ZohoConstants.ACCOUNTS_MODULE_NAME, paramInstance);
-      return getZohoRecord(response);
-    } catch (SDKException e) {
-      throw new ZohoException(
-          "Zoho search organization by organization name threw an exception", e);
-    }
-  }
-
-  private Optional<Record> getZohoRecord(APIResponse<ResponseHandler> response) {
-    return getZohoRecords(response).stream().findFirst();
-  }
-
-  private List<Record> getZohoRecords(APIResponse<ResponseHandler> response) {
-    if (response != null && response.isExpected()) {
-      // Get the object from response
-      ResponseHandler responseHandler = response.getObject();
-      if (responseHandler instanceof ResponseWrapper) {
-        ResponseWrapper responseWrapper = (ResponseWrapper) responseHandler;
-        return responseWrapper.getData();
-      }
-    }
-    return Collections.emptyList();
-  }
-
-  private List<DeletedRecord> getZohoDeletedRecords(APIResponse<DeletedRecordsHandler> response) {
-    if (response != null && response.isExpected()) {
-      // Get the object from response
-      DeletedRecordsHandler deletedRecordsHandler = response.getObject();
-      if (deletedRecordsHandler instanceof DeletedRecordsWrapper) {
-        DeletedRecordsWrapper deletedRecordsWrapper = (DeletedRecordsWrapper) deletedRecordsHandler;
-        return deletedRecordsWrapper.getData();
-      }
-    }
-    return Collections.emptyList();
-  }
-
   public Optional<Record> getZohoRecordOrganizationById(String zohoUrl) throws ZohoException {
-
     String zohoId = EntityRecordUtils.getIdFromUrl(zohoUrl);
     try {
       RecordOperations recordOperations = new RecordOperations();
@@ -167,153 +87,9 @@ public class ZohoAccessClient {
 
       APIResponse<ResponseHandler> response =
           recordOperations.searchRecords(ZohoConstants.ACCOUNTS_MODULE_NAME, paramInstance);
-      return getZohoRecord(response);
+      return getZohoRecords(response).stream().findFirst();
     } catch (SDKException e) {
       throw new ZohoException("Zoho search organization by organization id threw an exception", e);
     }
-  }
-
-  /**
-   * Get deleted organization items paged.
-   *
-   * @param startPage The number of the item from which the paging should start. First item is at
-   *     number 1. Uses default number of items per page.
-   * @return the list of deleted Zoho Organizations
-   * @throws ZohoException if an error occurred during accessing Zoho
-   */
-  public List<DeletedRecord> getZohoDeletedRecordOrganizations(int startPage) throws ZohoException {
-    if (startPage < 1) {
-      throw new ZohoException(
-          "Invalid start page index. Index must be >= 1",
-          new IllegalArgumentException("start page: " + startPage));
-    }
-    try {
-      RecordOperations recordOperations = new RecordOperations();
-      ParameterMap paramInstance = new ParameterMap();
-      paramInstance.add(GetDeletedRecordsParam.TYPE, "permanent"); // all, recycle, permanent
-      paramInstance.add(GetDeletedRecordsParam.PAGE, 1);
-      paramInstance.add(GetDeletedRecordsParam.PER_PAGE, ITEMS_PER_PAGE);
-      APIResponse<DeletedRecordsHandler> response =
-          recordOperations.getDeletedRecords(
-              ZohoConstants.ACCOUNTS_MODULE_NAME, paramInstance, new HeaderMap());
-      return getZohoDeletedRecords(response);
-    } catch (SDKException e) {
-      throw new ZohoException("Cannot get deleted organization list from: " + startPage, e);
-    }
-  }
-
-  /**
-   * Get organization items paged, filtering by modifiedDate date.
-   *
-   * @param start first index starts with 1
-   * @param rows the number of entries to be returned, Zoho will have an upper limit
-   * @param modifiedDate the date of last modification to check
-   * @return the list of Zoho Organizations
-   * @throws ZohoException if an error occurred during accessing Zoho
-   */
-  public List<Record> getZcrmRecordOrganizations(int start, int rows, OffsetDateTime modifiedDate)
-      throws ZohoException {
-    return getZcrmRecordOrganizations(start, rows, modifiedDate, null, null);
-  }
-
-  /**
-   * Get organization items paged, filtering by modifiedDate date and searchCriteria.
-   *
-   * @param page first index starts with 1
-   * @param pageSize the number of entries to be returned, Zoho will have an upper limit.
-   * @param modifiedDate the date of last modification to check
-   * @param searchCriteria the searchCriteria to apply during the Zoho search
-   * @param criteriaOperator the criteriaOperator used for each parameter, can be one of {@link
-   *     ZohoConstants#EQUALS_OPERATION},{@link ZohoConstants#STARTS_WITH_OPERATION}. If not
-   *     provided or wrong value, it will default to {@link ZohoConstants#EQUALS_OPERATION}.
-   * @return the list of Zoho Organizations
-   * @throws ZohoException if an error occurred during accessing Zoho
-   */
-  public List<Record> getZcrmRecordOrganizations(
-      int page,
-      int pageSize,
-      OffsetDateTime modifiedDate,
-      Map<String, String> searchCriteria,
-      String criteriaOperator)
-      throws ZohoException {
-
-    if (page < 1 || pageSize < 1) {
-      throw new ZohoException(
-          "Invalid page or pageSize index. Index must be >= 1",
-          new IllegalArgumentException(
-              String.format("Provided page: %s, and pageSize: %s", page, pageSize)));
-    }
-    int start = ((page - 1) * pageSize) + 1;
-
-    try {
-      APIResponse<ResponseHandler> response;
-      RecordOperations recordOperations = new RecordOperations();
-      ParameterMap paramInstance = new ParameterMap();
-      if (isNullOrEmpty(searchCriteria)) { // No searchCriteria available
-        paramInstance.add(GetRecordsParam.PAGE, start);
-        paramInstance.add(GetRecordsParam.PER_PAGE, pageSize);
-        HeaderMap headerInstance = new HeaderMap();
-        headerInstance.add(GetRecordsHeader.IF_MODIFIED_SINCE, modifiedDate);
-        response =
-            recordOperations.getRecords(
-                ZohoConstants.ACCOUNTS_MODULE_NAME, paramInstance, headerInstance);
-
-      } else {
-        paramInstance.add(SearchRecordsParam.PAGE, start);
-        paramInstance.add(SearchRecordsParam.PER_PAGE, pageSize);
-        paramInstance.add(
-            SearchRecordsParam.CRITERIA,
-            createZohoCriteriaString(searchCriteria, criteriaOperator));
-        response =
-            recordOperations.searchRecords(ZohoConstants.ACCOUNTS_MODULE_NAME, paramInstance);
-      }
-      return getZohoRecords(response);
-    } catch (SDKException e) {
-      throw new ZohoException(
-          "Cannot get organization list from: " + start + " rows :" + pageSize, e);
-    }
-  }
-
-  /**
-   * Using the search criteria provided and the modifiedDate if available it will create the
-   * criteria in the format that Zoho accepts. Result will be depicted as
-   * "(field1:equals:valueA)OR(field1:equals:valueB)OR(field2:equals:valueC)" or "".
-   *
-   * @param searchCriteria the search criteria map provided, values can be comma separated per key
-   * @param criteriaOperator the criteriaOperator used for each parameter, can be one of {@link
-   *     ZohoConstants#EQUALS_OPERATION},{@link ZohoConstants#STARTS_WITH_OPERATION}. If not
-   *     provided or wrong value, it will default to {@link ZohoConstants#EQUALS_OPERATION}.
-   * @return the created criteria in the format Zoho accepts
-   */
-  private String createZohoCriteriaString(
-      Map<String, String> searchCriteria, String criteriaOperator) {
-    if (isNullOrEmpty(searchCriteria)) {
-      searchCriteria = new HashMap<>();
-    }
-
-    if (Objects.isNull(criteriaOperator)
-        || (!ZohoConstants.EQUALS_OPERATION.equals(criteriaOperator)
-            && !ZohoConstants.STARTS_WITH_OPERATION.equals(criteriaOperator))) {
-      criteriaOperator = ZohoConstants.EQUALS_OPERATION;
-    }
-
-    String finalCriteriaOperator = criteriaOperator;
-    return searchCriteria.entrySet().stream()
-        .map(
-            entry ->
-                Arrays.stream(entry.getValue().split(ZohoConstants.DELIMITER_COMMA))
-                    .map(
-                        value ->
-                            String.format(
-                                ZohoConstants.ZOHO_OPERATION_FORMAT_STRING,
-                                entry.getKey(),
-                                finalCriteriaOperator,
-                                value.trim()))
-                    .collect(Collectors.joining(ZohoConstants.OR)))
-        .collect(Collectors.joining(ZohoConstants.OR));
-  }
-
-  private static boolean isNullOrEmpty(final Map<?, ?> m) {
-    return m == null || m.isEmpty();
   }
 }

--- a/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/zoho/organization/ZohoAccessConfiguration.java
+++ b/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/zoho/organization/ZohoAccessConfiguration.java
@@ -2,6 +2,7 @@ package eu.europeana.entitymanagement.zoho.organization;
 
 import eu.europeana.entitymanagement.common.config.AppConfigConstants;
 import eu.europeana.entitymanagement.zoho.ZohoAccessClient;
+import eu.europeana.entitymanagement.zoho.utils.ZohoException;
 import eu.europeana.entitymanagement.zoho.utils.ZohoInMemoryTokenStore;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -28,7 +29,7 @@ public class ZohoAccessConfiguration {
 
   private volatile ZohoAccessClient zohoAccessClient;
 
-  public ZohoAccessClient getZohoAccessClient() {
+  public ZohoAccessClient getZohoAccessClient() throws ZohoException {
     if (zohoAccessClient == null) {
       synchronized (this) {
         if (zohoAccessClient == null) {

--- a/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/zoho/organization/ZohoAccessConfiguration.java
+++ b/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/zoho/organization/ZohoAccessConfiguration.java
@@ -1,21 +1,8 @@
 package eu.europeana.entitymanagement.zoho.organization;
 
-import com.zoho.api.authenticator.OAuthToken;
-import com.zoho.api.authenticator.OAuthToken.TokenType;
-import com.zoho.api.authenticator.store.FileStore;
-import com.zoho.api.authenticator.store.TokenStore;
-import com.zoho.crm.api.Initializer;
-import com.zoho.crm.api.SDKConfig;
-import com.zoho.crm.api.UserSignature;
-import com.zoho.crm.api.dc.DataCenter.Environment;
-import com.zoho.crm.api.dc.USDataCenter;
 import eu.europeana.entitymanagement.common.config.AppConfigConstants;
 import eu.europeana.entitymanagement.zoho.ZohoAccessClient;
-import java.io.File;
-import java.io.IOException;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import eu.europeana.entitymanagement.zoho.utils.ZohoInMemoryTokenStore;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
@@ -23,12 +10,6 @@ import org.springframework.context.annotation.PropertySource;
 @Configuration(AppConfigConstants.BEAN_ZOHO_ACCESS_CONFIGURATION)
 @PropertySource(value = "classpath:zoho_import.properties", ignoreResourceNotFound = true)
 public class ZohoAccessConfiguration {
-
-  private static final Logger LOGGER = LogManager.getLogger(ZohoAccessConfiguration.class);
-
-  public ZohoAccessConfiguration() {
-    LOGGER.info("Initializing ZohoOrganizationImporterConfiguration bean as: configuration.");
-  }
 
   @Value("${zoho.email:#{null}}")
   private String zohoEmail;
@@ -39,87 +20,29 @@ public class ZohoAccessConfiguration {
   @Value("${zoho.client.secret:#{null}}")
   private String zohoClientSecret;
 
-  @Value("${zoho.grant.token:#{null}}")
-  private String zohoGrantToken;
-
   @Value("${zoho.refresh.token:#{null}}")
   private String zohoRefreshToken;
 
   @Value("${zoho.redirect.url:#{null}}")
   private String zohoRedirectUrl;
 
-  @Value("${token.store.file.path:#{null}}")
-  private String tokenFile;
+  private volatile ZohoAccessClient zohoAccessClient;
 
-  TokenStore fileTokenStore;
-
-  ZohoAccessClient zohoAccessClient;
-
-  TokenStore getFileTokenStore() throws Exception {
-    if (fileTokenStore != null) {
-      return fileTokenStore;
+  public ZohoAccessClient getZohoAccessClient() {
+    if (zohoAccessClient == null) {
+      synchronized (this) {
+        if (zohoAccessClient == null) {
+          zohoAccessClient =
+              new ZohoAccessClient(
+                  new ZohoInMemoryTokenStore(),
+                  zohoEmail,
+                  zohoClientId,
+                  zohoClientSecret,
+                  zohoRefreshToken,
+                  zohoRedirectUrl);
+        }
+      }
     }
-
-    if (StringUtils.isBlank(tokenFile)) {
-      return null;
-    }
-
-    File tokenStoreFile = new File(tokenFile);
-    initTokenStore(tokenStoreFile);
-
-    return fileTokenStore;
-  }
-
-  void initTokenStore(File tokenStoreFile) throws Exception {
-    if (tokenStoreFile.exists()) {
-      // create fresh token store
-      tokenStoreFile.delete();
-    } else {
-      if (tokenStoreFile.getParentFile() != null) tokenStoreFile.getParentFile().mkdirs();
-    }
-    // create empty token store
-    boolean created = tokenStoreFile.createNewFile();
-    if (!created) {
-      throw new IOException(
-          "Cannot create token store. Please verify the properties for the configuration of file token store and verify that the application has permissions to create the file for the token store. ");
-    }
-    fileTokenStore = new FileStore(tokenStoreFile.getAbsolutePath());
-  }
-
-  public ZohoAccessClient getZohoAccessClient() throws Exception {
-    if (zohoAccessClient != null) {
-      return zohoAccessClient;
-    }
-
-    if (zohoGrantToken == null || zohoGrantToken.length() < 6) {
-      throw new IllegalArgumentException("zoho.authentication.token is invalid: " + zohoGrantToken);
-    }
-    LOGGER.info("Using zoho authentication token: {} ...", zohoGrantToken.substring(0, 3));
-    zohoAccessClient =
-        new ZohoAccessClient(
-            getFileTokenStore(),
-            zohoEmail,
-            zohoClientId,
-            zohoClientSecret,
-            zohoGrantToken,
-            zohoRedirectUrl);
-
-    if (!StringUtils.isBlank(zohoRefreshToken)) {
-      // if available, switch to the use of existing refresh token
-      OAuthToken refreshToken =
-          new OAuthToken(
-              zohoClientId, zohoClientSecret, zohoRefreshToken, TokenType.REFRESH, zohoRedirectUrl);
-      refreshToken.setUserMail(zohoEmail);
-      refreshToken.setAccessToken("accessToken-placeholder");
-      refreshToken.setExpiresIn("0");
-      fileTokenStore.saveToken(new UserSignature(zohoEmail), refreshToken);
-
-      SDKConfig sdkConfig =
-          new SDKConfig.Builder().setAutoRefreshFields(false).setPickListValidation(true).build();
-      Environment environment = USDataCenter.PRODUCTION;
-      Initializer.switchUser(new UserSignature(zohoEmail), environment, refreshToken, sdkConfig);
-    }
-
     return zohoAccessClient;
   }
 }

--- a/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/zoho/utils/ZohoException.java
+++ b/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/zoho/utils/ZohoException.java
@@ -1,11 +1,12 @@
 package eu.europeana.entitymanagement.zoho.utils;
 
+import eu.europeana.api.commons.error.EuropeanaApiException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 /** Exception for describing zoho type of exceptions. */
 @ResponseStatus(value = HttpStatus.NOT_ACCEPTABLE, reason = "Bad Content")
-public class ZohoException extends Exception {
+public class ZohoException extends EuropeanaApiException {
 
   private static final long serialVersionUID = -3332292346834265371L;
 

--- a/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/zoho/utils/ZohoInMemoryTokenStore.java
+++ b/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/zoho/utils/ZohoInMemoryTokenStore.java
@@ -1,0 +1,50 @@
+package eu.europeana.entitymanagement.zoho.utils;
+
+import com.zoho.api.authenticator.Token;
+import com.zoho.api.authenticator.store.TokenStore;
+import com.zoho.crm.api.UserSignature;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ZohoInMemoryTokenStore implements TokenStore {
+
+  /** Contains tokens mapped to user email addresses */
+  private final Map<String, Token> tokenStore = new ConcurrentHashMap<>();
+
+  /**
+   * @param user A UserSignature class instance.
+   * @param token A Token (com.zoho.api.authenticator.OAuthToken) class instance.
+   * @return A Token class instance representing the user token details.
+   */
+  @Override
+  public Token getToken(UserSignature user, Token token) {
+    return tokenStore.get(user.getEmail());
+  }
+
+  /**
+   * @param user A UserSignature class instance.
+   * @param token A Token (com.zoho.api.authenticator.OAuthToken) class instance.
+   */
+  @Override
+  public void saveToken(UserSignature user, Token token) {
+    tokenStore.put(user.getEmail(), token);
+  }
+
+  /** @param token A Token (com.zoho.api.authenticator.OAuthToken) class instance. */
+  @Override
+  public void deleteToken(Token token) {
+    tokenStore.entrySet().removeIf(entry -> (token.equals(entry.getValue())));
+  }
+
+  @Override
+  public List<Token> getTokens() {
+    return new ArrayList<>(tokenStore.values());
+  }
+
+  @Override
+  public void deleteTokens() {
+    tokenStore.clear();
+  }
+}

--- a/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/zoho/utils/ZohoUtils.java
+++ b/entity-management-zoho/src/main/java/eu/europeana/entitymanagement/zoho/utils/ZohoUtils.java
@@ -1,5 +1,9 @@
 package eu.europeana.entitymanagement.zoho.utils;
 
+import com.zoho.crm.api.record.Record;
+import com.zoho.crm.api.record.ResponseHandler;
+import com.zoho.crm.api.record.ResponseWrapper;
+import com.zoho.crm.api.util.APIResponse;
 import com.zoho.crm.api.util.Choice;
 import eu.europeana.entitymanagement.common.config.DataSources;
 import eu.europeana.entitymanagement.definitions.model.WebResource;
@@ -293,5 +297,17 @@ public final class ZohoUtils {
   public static boolean isZohoOrganization(String id, String entityType) {
     return EntityTypes.Organization.getEntityType().equals(entityType)
         && id.contains(DataSources.ZOHO_ID);
+  }
+
+  public static List<Record> getZohoRecords(APIResponse<ResponseHandler> response) {
+    if (response != null && response.isExpected()) {
+      // Get the object from response
+      ResponseHandler responseHandler = response.getObject();
+      if (responseHandler instanceof ResponseWrapper) {
+        ResponseWrapper responseWrapper = (ResponseWrapper) responseHandler;
+        return responseWrapper.getData();
+      }
+    }
+    return Collections.emptyList();
   }
 }

--- a/entity-management-zoho/src/main/resources/zoho_import.properties.template
+++ b/entity-management-zoho/src/main/resources/zoho_import.properties.template
@@ -1,7 +1,5 @@
 zoho.email=
 zoho.client.id=
 zoho.client.secret=
-zoho.grant.token=
 zoho.refresh.token=
 zoho.redirect.url=
-token.store.file.path=


### PR DESCRIPTION
This PR:

-  replaces the Zoho File TokenStore with a custom in-memory implementation
-  improves thread-safety in Wikidata and Zoho dereferencing
-  removes unused code from `ZohoAccessClient`