### PR TITLE
EA-2736: Optimise EntityRecord retrieval via ScheduledTasks

### DIFF
--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/EntityRecord.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/model/EntityRecord.java
@@ -18,13 +18,7 @@ import org.bson.types.ObjectId;
 
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 @dev.morphia.annotations.Entity("EntityRecord")
-@Indexes({
-  @Index(fields = {@Field(ENTITY_EXACT_MATCH)}),
-  @Index(fields = {@Field(ENTITY_SAME_AS)}),
-
-  // temporary index for migration
-  @Index(fields = @Field(ENTITY_TYPE))
-})
+@Indexes({@Index(fields = {@Field(ENTITY_EXACT_MATCH)}), @Index(fields = {@Field(ENTITY_SAME_AS)})})
 @EntityListeners(EntityRecordWatcher.class)
 public class EntityRecord {
 

--- a/entity-management-web/src/integration-test/java/eu/europeana/entitymanagement/AbstractIntegrationTest.java
+++ b/entity-management-web/src/integration-test/java/eu/europeana/entitymanagement/AbstractIntegrationTest.java
@@ -6,11 +6,19 @@ import static eu.europeana.entitymanagement.testutils.BaseMvcTestUtils.ORGANIZAT
 import static eu.europeana.entitymanagement.testutils.BaseMvcTestUtils.ORGANIZATION_BNF_WIKIDATA_RESPONSE_XML;
 import static eu.europeana.entitymanagement.testutils.BaseMvcTestUtils.loadFile;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.europeana.entitymanagement.batch.service.EntityUpdateService;
+import eu.europeana.entitymanagement.common.config.AppConfigConstants;
+import eu.europeana.entitymanagement.definitions.model.EntityRecord;
 import eu.europeana.entitymanagement.testutils.MongoContainer;
 import eu.europeana.entitymanagement.testutils.SolrContainer;
+import eu.europeana.entitymanagement.web.MetisDereferenceUtils;
+import eu.europeana.entitymanagement.web.model.EntityPreview;
 import eu.europeana.entitymanagement.web.service.EntityRecordService;
+import eu.europeana.entitymanagement.web.xml.model.XmlBaseEntityImpl;
 import java.io.IOException;
 import java.util.Objects;
+import javax.xml.bind.JAXBContext;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -21,6 +29,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
@@ -36,6 +45,14 @@ public abstract class AbstractIntegrationTest {
   private static final Logger logger = LogManager.getLogger(AbstractIntegrationTest.class);
   private static final MongoContainer MONGO_CONTAINER;
   private static final SolrContainer SOLR_CONTAINER;
+
+  @Autowired protected JAXBContext jaxbContext;
+
+  @Qualifier(AppConfigConstants.BEAN_JSON_MAPPER)
+  @Autowired
+  protected ObjectMapper objectMapper;
+
+  @Autowired protected EntityUpdateService entityUpdateService;
 
   static {
     MONGO_CONTAINER =
@@ -159,5 +176,23 @@ public abstract class AbstractIntegrationTest {
         return new MockResponse().setResponseCode(404);
       }
     };
+  }
+
+  protected EntityRecord createEntity(
+      String europeanaMetadata, String metisResponse, String externalId) throws Exception {
+    EntityPreview entityPreview = objectMapper.readValue(europeanaMetadata, EntityPreview.class);
+    XmlBaseEntityImpl<?> xmlBaseEntity =
+        MetisDereferenceUtils.parseMetisResponse(
+            jaxbContext.createUnmarshaller(), externalId, metisResponse);
+
+    assert xmlBaseEntity != null;
+    EntityRecord savedRecord =
+        entityRecordService.createEntityFromRequest(entityPreview, xmlBaseEntity.toEntityModel());
+
+    // trigger update to generate consolidated entity
+    entityUpdateService.runSynchronousUpdate(savedRecord.getEntityId());
+
+    // return entityRecord version with consolidated entity
+    return entityRecordService.retrieveByEntityId(savedRecord.getEntityId()).orElseThrow();
   }
 }

--- a/entity-management-web/src/integration-test/java/eu/europeana/entitymanagement/web/BaseWebControllerTest.java
+++ b/entity-management-web/src/integration-test/java/eu/europeana/entitymanagement/web/BaseWebControllerTest.java
@@ -7,12 +7,9 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zoho.crm.api.record.Record;
 import eu.europeana.entitymanagement.AbstractIntegrationTest;
-import eu.europeana.entitymanagement.batch.service.EntityUpdateService;
 import eu.europeana.entitymanagement.batch.service.ScheduledTaskService;
-import eu.europeana.entitymanagement.common.config.AppConfigConstants;
 import eu.europeana.entitymanagement.definitions.batch.model.ScheduledTask;
 import eu.europeana.entitymanagement.definitions.batch.model.ScheduledTaskType;
 import eu.europeana.entitymanagement.definitions.model.EntityRecord;
@@ -20,19 +17,16 @@ import eu.europeana.entitymanagement.solr.exception.SolrServiceException;
 import eu.europeana.entitymanagement.solr.service.SolrService;
 import eu.europeana.entitymanagement.testutils.TestConfig;
 import eu.europeana.entitymanagement.web.model.EntityPreview;
-import eu.europeana.entitymanagement.web.xml.model.XmlBaseEntityImpl;
 import eu.europeana.entitymanagement.zoho.organization.ZohoOrganizationConverter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Optional;
-import javax.xml.bind.JAXBContext;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
@@ -45,17 +39,9 @@ abstract class BaseWebControllerTest extends AbstractIntegrationTest {
 
   protected MockMvc mockMvc;
 
-  @Autowired private JAXBContext jaxbContext;
-
   @Autowired protected SolrService solrService;
 
   @Autowired protected ScheduledTaskService scheduledTaskService;
-
-  @Autowired private EntityUpdateService entityUpdateService;
-
-  @Qualifier(AppConfigConstants.BEAN_JSON_MAPPER)
-  @Autowired
-  private ObjectMapper objectMapper;
 
   @Autowired private WebApplicationContext webApplicationContext;
 
@@ -140,24 +126,6 @@ abstract class BaseWebControllerTest extends AbstractIntegrationTest {
                     containsString("DELETE"),
                     containsString("POST"),
                     containsString("PUT"))));
-  }
-
-  protected EntityRecord createEntity(
-      String europeanaMetadata, String metisResponse, String externalId) throws Exception {
-    EntityPreview entityPreview = objectMapper.readValue(europeanaMetadata, EntityPreview.class);
-    XmlBaseEntityImpl<?> xmlBaseEntity =
-        MetisDereferenceUtils.parseMetisResponse(
-            jaxbContext.createUnmarshaller(), externalId, metisResponse);
-
-    assert xmlBaseEntity != null;
-    EntityRecord savedRecord =
-        entityRecordService.createEntityFromRequest(entityPreview, xmlBaseEntity.toEntityModel());
-
-    // trigger update to generate consolidated entity
-    entityUpdateService.runSynchronousUpdate(savedRecord.getEntityId());
-
-    // return entityRecord version with consolidated entity
-    return entityRecordService.retrieveByEntityId(savedRecord.getEntityId()).orElseThrow();
   }
 
   protected EntityRecord createOrganization(String europeanaMetadata, Record zohoOrganization)

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/batch/repository/ScheduledTaskRepository.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/batch/repository/ScheduledTaskRepository.java
@@ -1,6 +1,6 @@
 package eu.europeana.entitymanagement.batch.repository;
 
-import static dev.morphia.query.Sort.ascending;
+import static dev.morphia.aggregation.experimental.expressions.Expressions.field;
 import static dev.morphia.query.experimental.filters.Filters.eq;
 import static dev.morphia.query.experimental.filters.Filters.gte;
 import static dev.morphia.query.experimental.filters.Filters.in;
@@ -15,8 +15,9 @@ import com.mongodb.client.model.WriteModel;
 import dev.morphia.Datastore;
 import dev.morphia.aggregation.experimental.stages.Lookup;
 import dev.morphia.aggregation.experimental.stages.Projection;
+import dev.morphia.aggregation.experimental.stages.ReplaceRoot;
+import dev.morphia.aggregation.experimental.stages.Sort;
 import dev.morphia.aggregation.experimental.stages.Unwind;
-import dev.morphia.query.FindOptions;
 import dev.morphia.query.experimental.filters.Filter;
 import dev.morphia.query.internal.MorphiaCursor;
 import eu.europeana.entitymanagement.common.config.AppConfigConstants;
@@ -27,7 +28,6 @@ import eu.europeana.entitymanagement.definitions.batch.model.ScheduledUpdateType
 import eu.europeana.entitymanagement.definitions.model.EntityRecord;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.bson.Document;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -142,35 +142,30 @@ public class ScheduledTaskRepository implements InitializingBean {
 
   /**
    * Queries the ScheduledTasks collection for records that match the given filter(s). Then
-   * retrieves the matching EntityRecords Results are sorted in ascending order of created
+   * retrieves the matching EntityRecords. Results are sorted in ascending order of entityId.
    *
    * @param filters Query filters
    * @return List with results
    */
   public List<? extends EntityRecord> getEntityRecordsForTasks(
       int start, int count, Filter[] filters) {
-    List<ScheduledTask> scheduledTasks =
-        datastore
-            .find(ScheduledTask.class)
-            .filter(filters)
-            .iterator(
-                new FindOptions()
-                    // we only care about the EntityID
-                    .projection()
-                    .include(ENTITY_ID)
-                    .skip(start)
-                    // matches the index sort order defined in ScheduledTask
-                    .sort(ascending(CREATED))
-                    .limit(count))
-            .toList();
-
-    List<String> matchingIds =
-        scheduledTasks.stream().map(ScheduledTask::getEntityId).collect(Collectors.toList());
-
     return datastore
-        .find(EntityRecord.class)
-        .filter(in(ENTITY_ID, matchingIds))
-        .iterator()
+        .aggregate(ScheduledTask.class)
+        .match(filters)
+        .lookup(
+            Lookup.from(EntityRecord.class)
+                // both collections use the same entityId field name
+                .localField(ENTITY_ID)
+                .foreignField(ENTITY_ID)
+                .as("entity_record_lookup"))
+        .unwind(Unwind.on("entity_record_lookup"))
+        .replaceRoot(ReplaceRoot.with(field("entity_record_lookup")))
+        // Sort order required for pagination. EntityRecord.entityId is already indexed, so we use
+        // it
+        .sort(Sort.on().ascending(ENTITY_ID))
+        .skip(start)
+        .limit(count)
+        .execute(EntityRecord.class)
         .toList();
   }
 


### PR DESCRIPTION
- use $lookup function instead of querying each collection separately