### PR TITLE
EA-2736: Improve ScheduledTask housekeeping

### DIFF
--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/batch/model/ScheduledTask.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/batch/model/ScheduledTask.java
@@ -4,7 +4,6 @@ import dev.morphia.annotations.Entity;
 import dev.morphia.annotations.Field;
 import dev.morphia.annotations.Id;
 import dev.morphia.annotations.Index;
-import dev.morphia.annotations.IndexOptions;
 import dev.morphia.annotations.Indexed;
 import dev.morphia.annotations.Indexes;
 import eu.europeana.entitymanagement.definitions.batch.EMBatchConstants;
@@ -13,13 +12,12 @@ import org.bson.types.ObjectId;
 
 @Entity("ScheduledTasks")
 @Indexes({
-  @Index(fields = {@Field(EMBatchConstants.CREATED), @Field(EMBatchConstants.UPDATE_TYPE)}),
-  // only index records where hasBeenProcessed = true
   @Index(
-      options =
-          @IndexOptions(
-              partialFilter = "{" + EMBatchConstants.HAS_BEEN_PROCESSED + " : { $eq : true } }"),
-      fields = {@Field(EMBatchConstants.HAS_BEEN_PROCESSED)})
+      fields = {
+        @Field(value = EMBatchConstants.CREATED),
+        @Field(EMBatchConstants.UPDATE_TYPE),
+        @Field(EMBatchConstants.HAS_BEEN_PROCESSED)
+      }),
 })
 public class ScheduledTask {
 

--- a/entity-management-web/src/integration-test/java/eu/europeana/entitymanagement/batch/service/ScheduledTaskServiceIT.java
+++ b/entity-management-web/src/integration-test/java/eu/europeana/entitymanagement/batch/service/ScheduledTaskServiceIT.java
@@ -118,7 +118,7 @@ class ScheduledTaskServiceIT extends AbstractIntegrationTest {
     failedTaskRepository.upsert(failedTask1);
 
     // remove scheduled tasks with failureCount >= 2
-    service.removeScheduledTasksWithFailures(2);
+    service.removeScheduledTasksWithFailures(2, testUpdateType);
 
     List<ScheduledTask> tasks = service.getTasks(entityIds);
 

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/batch/listener/EntityUpdateStepListener.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/batch/listener/EntityUpdateStepListener.java
@@ -48,7 +48,7 @@ public class EntityUpdateStepListener implements StepExecutionListener {
      * them if they're manually scheduled again.
      */
 
-    scheduledTaskService.removeScheduledTasksWithFailures(maxFailedTaskRetries);
+    scheduledTaskService.removeScheduledTasksWithFailures(maxFailedTaskRetries, updateType);
     return ExitStatus.COMPLETED;
   }
 }

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/batch/repository/ScheduledTaskRepository.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/batch/repository/ScheduledTaskRepository.java
@@ -190,11 +190,12 @@ public class ScheduledTaskRepository implements InitializingBean {
    * Gets all ScheduledTasks with failures, whose failureCount is above the maxFailedTaskRetries
    * value. Note: this method returns a cursor, which callers are responsible for closing
    */
-  public MorphiaCursor<ScheduledTask> getTasksWithFailures(int maxFailedTaskRetries) {
+  public MorphiaCursor<ScheduledTask> getTasksWithFailures(
+      int maxFailedTaskRetries, ScheduledTaskType updateType) {
 
     return datastore
         .aggregate(ScheduledTask.class)
-        .match(eq(HAS_BEEN_PROCESSED, false))
+        .match(eq(HAS_BEEN_PROCESSED, false), eq(UPDATE_TYPE, updateType.getValue()))
         // both collections use the same entityId field name
         .lookup(
             Lookup.from(FailedTask.class)

--- a/entity-management-web/src/main/java/eu/europeana/entitymanagement/batch/service/ScheduledTaskService.java
+++ b/entity-management-web/src/main/java/eu/europeana/entitymanagement/batch/service/ScheduledTaskService.java
@@ -80,12 +80,13 @@ public class ScheduledTaskService {
    * Removes unprocessed entries from the ScheduledTasks collection if the FailedTasks retryCount is
    * equal or greater than the max number of retries allowed.
    *
-   * <p>TODO: investigate if this can be replace with a delete query
+   * <p>TODO: investigate if this can be replaced with a delete query
    */
-  public void removeScheduledTasksWithFailures(int maxFailedTaskRetries) {
+  public void removeScheduledTasksWithFailures(
+      int maxFailedTaskRetries, ScheduledTaskType updateType) {
 
     try (MorphiaCursor<ScheduledTask> cursor =
-        repository.getTasksWithFailures(maxFailedTaskRetries)) {
+        repository.getTasksWithFailures(maxFailedTaskRetries, updateType)) {
 
       while (cursor.hasNext()) {
         repository.deleteScheduledTask(cursor.next().getEntityId());


### PR DESCRIPTION
- only tasks for the current update type are now deleted during cleanup
- database indexes updated