### PR TITLE
EA-2855: Improve memory usage when scheduling updates via search

### DIFF
--- a/entity-management-common/src/main/java/eu/europeana/entitymanagement/common/config/EntityManagementConfiguration.java
+++ b/entity-management-common/src/main/java/eu/europeana/entitymanagement/common/config/EntityManagementConfiguration.java
@@ -52,7 +52,7 @@ public class EntityManagementConfiguration {
   @Value("${entitymanagement.solr.indexing.explicitCommits: false}")
   private boolean explicitCommitsEnabled;
 
-  @Value("${entitymanagement.solr.indexing.query.maxPageSize: 100}")
+  @Value("${entitymanagement.solr.indexing.query.maxPageSize: 300}")
   private int solrQueryMaxPageSize;
 
   @Value("${entitymanagement.solr.searchapi.hits.query}")

--- a/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/web/EntityIdResponse.java
+++ b/entity-management-definitions/src/main/java/eu/europeana/entitymanagement/definitions/web/EntityIdResponse.java
@@ -1,15 +1,22 @@
 package eu.europeana.entitymanagement.definitions.web;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.ArrayList;
 import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class EntityIdResponse {
 
   private long expected;
-  private List<String> successful;
-  private List<String> skipped;
-  private List<String> failed;
+  private final List<String> successful;
+  private final List<String> skipped;
+  private final List<String> failed;
+
+  public EntityIdResponse() {
+    this.successful = new ArrayList<>();
+    this.skipped = new ArrayList<>();
+    this.failed = new ArrayList<>();
+  }
 
   public EntityIdResponse(
       long expected, List<String> successful, List<String> failed, List<String> skipped) {
@@ -27,11 +34,19 @@ public class EntityIdResponse {
     return successful;
   }
 
+  public List<String> getSkipped() {
+    return skipped;
+  }
+
   public List<String> getFailed() {
     return failed;
   }
 
-  public List<String> getSkipped() {
-    return skipped;
+  public void updateValues(
+      int expected, List<String> successful, List<String> failed, List<String> skipped) {
+    this.expected += expected;
+    this.successful.addAll(successful);
+    this.failed.addAll(failed);
+    this.skipped.addAll(skipped);
   }
 }


### PR DESCRIPTION
- schedule using chunked Solr cursor results, instead of waiting until all results are retrieved
- increased default Solr query pageSize from 100 to 300